### PR TITLE
[BE] 폴더를 조회한다.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -34,6 +34,13 @@ dependencies {
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+
+
+	// queryDSL
+	implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
+	annotationProcessor "com.querydsl:querydsl-apt:5.0.0:jakarta"
+	annotationProcessor "jakarta.annotation:jakarta.annotation-api"
+	annotationProcessor "jakarta.persistence:jakarta.persistence-api"
 }
 
 tasks.named('test') {

--- a/src/main/java/com/woowacamp/storage/domain/file/entity/FileMetadata.java
+++ b/src/main/java/com/woowacamp/storage/domain/file/entity/FileMetadata.java
@@ -20,9 +20,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
-@Table(
-	name = "file_metadata", indexes = @Index(name = "file_idx_parent_folder_id", columnList = "parent_folder_id")
-)
+@Table(name = "file_metadata", indexes = @Index(name = "file_idx_parent_folder_id", columnList = "parent_folder_id"))
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
 public class FileMetadata {
@@ -58,7 +56,7 @@ public class FileMetadata {
 
 	@Column(name = "file_size", columnDefinition = "BIGINT NOT NULL")
 	@NotNull
-	private Long fileSize;
+	private Long size;
 
 	@Column(name = "upload_file_name", columnDefinition = "VARCHAR(100) NOT NULL")
 	@NotNull
@@ -75,7 +73,7 @@ public class FileMetadata {
 
 	@Builder
 	private FileMetadata(Long id, Long rootId, Long creatorId, String fileType, LocalDateTime createdAt,
-		LocalDateTime updatedAt, Long parentFolderId, Long fileSize, String uploadFileName, String uuidFileName,
+		LocalDateTime updatedAt, Long parentFolderId, Long size, String uploadFileName, String uuidFileName,
 		UploadStatus uploadStatus) {
 		this.id = id;
 		this.rootId = rootId;
@@ -84,7 +82,7 @@ public class FileMetadata {
 		this.createdAt = createdAt;
 		this.updatedAt = updatedAt;
 		this.parentFolderId = parentFolderId;
-		this.fileSize = fileSize;
+		this.size = size;
 		this.uploadFileName = uploadFileName;
 		this.uuidFileName = uuidFileName;
 		this.uploadStatus = uploadStatus;

--- a/src/main/java/com/woowacamp/storage/domain/file/entity/FileMetadata.java
+++ b/src/main/java/com/woowacamp/storage/domain/file/entity/FileMetadata.java
@@ -20,7 +20,10 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
-@Table(name = "file_metadata", indexes = @Index(name = "file_idx_parent_folder_id", columnList = "parent_folder_id"))
+@Table(name = "file_metadata", indexes = {
+	@Index(name = "file_idx_parent_folder_id_size", columnList = "parent_folder_id, created_at"),
+	@Index(name = "file_idx_parent_folder_id_created_at", columnList = "parent_folder_id, file_size")
+})
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
 public class FileMetadata {

--- a/src/main/java/com/woowacamp/storage/domain/file/entity/FileMetadata.java
+++ b/src/main/java/com/woowacamp/storage/domain/file/entity/FileMetadata.java
@@ -11,15 +11,17 @@ import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.Index;
 import jakarta.persistence.Table;
 import jakarta.validation.constraints.NotNull;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
 @Table(
-	name = "file_metadata"
+	name = "file_metadata", indexes = @Index(name = "file_idx_parent_folder_id", columnList = "parent_folder_id")
 )
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
@@ -70,4 +72,21 @@ public class FileMetadata {
 	@Column(name = "upload_status", columnDefinition = "VARCHAR(30) NOT NULL")
 	@NotNull
 	private UploadStatus uploadStatus;
+
+	@Builder
+	private FileMetadata(Long id, Long rootId, Long creatorId, String fileType, LocalDateTime createdAt,
+		LocalDateTime updatedAt, Long parentFolderId, Long fileSize, String uploadFileName, String uuidFileName,
+		UploadStatus uploadStatus) {
+		this.id = id;
+		this.rootId = rootId;
+		this.creatorId = creatorId;
+		this.fileType = fileType;
+		this.createdAt = createdAt;
+		this.updatedAt = updatedAt;
+		this.parentFolderId = parentFolderId;
+		this.fileSize = fileSize;
+		this.uploadFileName = uploadFileName;
+		this.uuidFileName = uuidFileName;
+		this.uploadStatus = uploadStatus;
+	}
 }

--- a/src/main/java/com/woowacamp/storage/domain/file/repository/FileCustomRepository.java
+++ b/src/main/java/com/woowacamp/storage/domain/file/repository/FileCustomRepository.java
@@ -1,0 +1,13 @@
+package com.woowacamp.storage.domain.file.repository;
+
+import java.util.List;
+
+import org.springframework.data.domain.Sort;
+
+import com.woowacamp.storage.domain.file.entity.FileMetadata;
+import com.woowacamp.storage.domain.folder.dto.FolderContentsSortField;
+
+public interface FileCustomRepository {
+	List<FileMetadata> findAllByParentIdAndCursorIdOrderBy(long parentId, long cursorId, FolderContentsSortField sortBy,
+		Sort.Direction direction, int limit);
+}

--- a/src/main/java/com/woowacamp/storage/domain/file/repository/FileCustomRepository.java
+++ b/src/main/java/com/woowacamp/storage/domain/file/repository/FileCustomRepository.java
@@ -8,6 +8,6 @@ import com.woowacamp.storage.domain.file.entity.FileMetadata;
 import com.woowacamp.storage.domain.folder.dto.FolderContentsSortField;
 
 public interface FileCustomRepository {
-	List<FileMetadata> findAllByParentIdAndCursorIdOrderBy(long parentId, long cursorId, FolderContentsSortField sortBy,
+	List<FileMetadata> selectFilesWithPagination(long parentId, long cursorId, FolderContentsSortField sortBy,
 		Sort.Direction direction, int limit);
 }

--- a/src/main/java/com/woowacamp/storage/domain/file/repository/FileCustomRepository.java
+++ b/src/main/java/com/woowacamp/storage/domain/file/repository/FileCustomRepository.java
@@ -1,5 +1,6 @@
 package com.woowacamp.storage.domain.file.repository;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 import org.springframework.data.domain.Sort;
@@ -9,5 +10,5 @@ import com.woowacamp.storage.domain.folder.dto.FolderContentsSortField;
 
 public interface FileCustomRepository {
 	List<FileMetadata> selectFilesWithPagination(long parentId, long cursorId, FolderContentsSortField sortBy,
-		Sort.Direction direction, int limit);
+		Sort.Direction direction, int limit, LocalDateTime time, Long size);
 }

--- a/src/main/java/com/woowacamp/storage/domain/file/repository/FileCustomRepositoryImpl.java
+++ b/src/main/java/com/woowacamp/storage/domain/file/repository/FileCustomRepositoryImpl.java
@@ -49,13 +49,13 @@ public class FileCustomRepositoryImpl implements FileCustomRepository {
 				break;
 			case DATA_SIZE:
 				if (direction.isAscending()) {
-					cursorCondition = fileMetadata.size.goe(size)
-						.and(fileMetadata.size.gt(size).or(fileMetadata.id.gt(cursorId)));
-					orderSpecifier = fileMetadata.size.asc();
+					cursorCondition = fileMetadata.fileSize.goe(size)
+						.and(fileMetadata.fileSize.gt(size).or(fileMetadata.id.gt(cursorId)));
+					orderSpecifier = fileMetadata.fileSize.asc();
 				} else {
-					cursorCondition = fileMetadata.size.loe(size)
-						.and(fileMetadata.size.lt(size).or(fileMetadata.id.gt(cursorId)));
-					orderSpecifier = fileMetadata.size.desc();
+					cursorCondition = fileMetadata.fileSize.loe(size)
+						.and(fileMetadata.fileSize.lt(size).or(fileMetadata.id.gt(cursorId)));
+					orderSpecifier = fileMetadata.fileSize.desc();
 				}
 				break;
 			default:

--- a/src/main/java/com/woowacamp/storage/domain/file/repository/FileCustomRepositoryImpl.java
+++ b/src/main/java/com/woowacamp/storage/domain/file/repository/FileCustomRepositoryImpl.java
@@ -1,5 +1,6 @@
 package com.woowacamp.storage.domain.file.repository;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 import org.springframework.data.domain.Sort;
@@ -22,7 +23,7 @@ public class FileCustomRepositoryImpl implements FileCustomRepository {
 	private final JPAQueryFactory queryFactory;
 
 	public List<FileMetadata> selectFilesWithPagination(long parentId, long cursorId,
-		FolderContentsSortField sortBy, Sort.Direction direction, int size) {
+		FolderContentsSortField sortBy, Sort.Direction direction, int limit, LocalDateTime time, Long size) {
 
 		// 기본 쿼리 구성 , where 조건 parentFolderId, uploadStatus
 		JPAQuery<FileMetadata> query = queryFactory.selectFrom(fileMetadata)
@@ -44,8 +45,8 @@ public class FileCustomRepositoryImpl implements FileCustomRepository {
 
 		// 정렬 조건 추가 (선택된 필드로 정렬 후, ID로 추가 정렬하여 일관성 유지)
 		query = query.orderBy(orderSpecifier, fileMetadata.id.asc());
-		// size 추가
-		query.limit(size);
+		// limit 추가
+		query.limit(limit);
 
 		return query.fetch();
 	}

--- a/src/main/java/com/woowacamp/storage/domain/file/repository/FileCustomRepositoryImpl.java
+++ b/src/main/java/com/woowacamp/storage/domain/file/repository/FileCustomRepositoryImpl.java
@@ -38,23 +38,23 @@ public class FileCustomRepositoryImpl implements FileCustomRepository {
 			case CREATED_AT:
 
 				if (direction.isAscending()) {
-					cursorCondition = fileMetadata.createdAt.gt(dateTime)
-						.or(fileMetadata.createdAt.eq(dateTime).and(fileMetadata.id.gt(cursorId)));
+					cursorCondition = fileMetadata.createdAt.goe(dateTime)
+						.and(fileMetadata.createdAt.gt(dateTime).or(fileMetadata.id.gt(cursorId)));
 					orderSpecifier = fileMetadata.createdAt.asc();
 				} else {
-					cursorCondition = fileMetadata.createdAt.lt(dateTime)
-						.or(fileMetadata.createdAt.eq(dateTime).and(fileMetadata.id.gt(cursorId)));
+					cursorCondition = fileMetadata.createdAt.loe(dateTime)
+						.and(fileMetadata.createdAt.lt(dateTime).or(fileMetadata.id.gt(cursorId)));
 					orderSpecifier = fileMetadata.createdAt.desc();
 				}
 				break;
 			case DATA_SIZE:
 				if (direction.isAscending()) {
-					cursorCondition = fileMetadata.size.gt(size)
-						.or(fileMetadata.size.eq(size).and(fileMetadata.id.gt(cursorId)));
+					cursorCondition = fileMetadata.size.goe(size)
+						.and(fileMetadata.size.gt(size).or(fileMetadata.id.gt(cursorId)));
 					orderSpecifier = fileMetadata.size.asc();
 				} else {
-					cursorCondition = fileMetadata.size.lt(size)
-						.or(fileMetadata.size.eq(size).and(fileMetadata.id.gt(cursorId)));
+					cursorCondition = fileMetadata.size.loe(size)
+						.and(fileMetadata.size.lt(size).or(fileMetadata.id.gt(cursorId)));
 					orderSpecifier = fileMetadata.size.desc();
 				}
 				break;

--- a/src/main/java/com/woowacamp/storage/domain/file/repository/FileCustomRepositoryImpl.java
+++ b/src/main/java/com/woowacamp/storage/domain/file/repository/FileCustomRepositoryImpl.java
@@ -1,0 +1,54 @@
+package com.woowacamp.storage.domain.file.repository;
+
+import java.util.List;
+
+import org.springframework.data.domain.Sort;
+import org.springframework.stereotype.Repository;
+
+import com.querydsl.core.types.OrderSpecifier;
+import com.querydsl.jpa.impl.JPAQuery;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.woowacamp.storage.domain.file.entity.FileMetadata;
+import com.woowacamp.storage.domain.file.entity.QFileMetadata;
+import com.woowacamp.storage.domain.folder.dto.FolderContentsSortField;
+import com.woowacamp.storage.global.constant.UploadStatus;
+
+import lombok.RequiredArgsConstructor;
+
+@Repository
+@RequiredArgsConstructor
+public class FileCustomRepositoryImpl implements FileCustomRepository {
+	private static final QFileMetadata fileMetadata = QFileMetadata.fileMetadata;
+	private final JPAQueryFactory queryFactory;
+
+	public List<FileMetadata> findAllByParentIdAndCursorIdOrderBy(long parentId, long cursorId,
+		FolderContentsSortField sortBy, Sort.Direction direction, int size) {
+
+		// 기본 쿼리 구성 , where 조건 parentFolderId, uploadStatus
+		JPAQuery<FileMetadata> query = queryFactory.selectFrom(fileMetadata)
+			.where(fileMetadata.parentFolderId.eq(parentId))
+			.where(fileMetadata.uploadStatus.eq(UploadStatus.SUCCESS))
+			.where(fileMetadata.id.gt(cursorId));
+
+		// 정렬 조건 적용
+		OrderSpecifier<?> orderSpecifier;
+		switch (sortBy) {
+			case CREATED_AT:
+				orderSpecifier = direction.isAscending() ? fileMetadata.createdAt.asc() : fileMetadata.createdAt.desc();
+				break;
+			case FOLDER_SIZE:
+				orderSpecifier = direction.isAscending() ? fileMetadata.size.asc() : fileMetadata.size.desc();
+				break;
+			default:
+				// 기본적으로 ID로 정렬
+				orderSpecifier = fileMetadata.id.asc();
+		}
+
+		// 정렬 조건 추가 (선택된 필드로 정렬 후, ID로 추가 정렬하여 일관성 유지)
+		query = query.orderBy(orderSpecifier, fileMetadata.id.asc());
+		// size 추가
+		query.limit(size);
+
+		return query.fetch();
+	}
+}

--- a/src/main/java/com/woowacamp/storage/domain/file/repository/FileCustomRepositoryImpl.java
+++ b/src/main/java/com/woowacamp/storage/domain/file/repository/FileCustomRepositoryImpl.java
@@ -7,6 +7,7 @@ import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Repository;
 
 import com.querydsl.core.types.OrderSpecifier;
+import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import com.woowacamp.storage.domain.file.entity.FileMetadata;
@@ -22,30 +23,54 @@ public class FileCustomRepositoryImpl implements FileCustomRepository {
 	private static final QFileMetadata fileMetadata = QFileMetadata.fileMetadata;
 	private final JPAQueryFactory queryFactory;
 
-	public List<FileMetadata> selectFilesWithPagination(long parentId, long cursorId,
-		FolderContentsSortField sortBy, Sort.Direction direction, int limit, LocalDateTime time, Long size) {
+	public List<FileMetadata> selectFilesWithPagination(long parentId, long cursorId, FolderContentsSortField sortBy,
+		Sort.Direction direction, int limit, LocalDateTime dateTime, Long size) {
 
 		// 기본 쿼리 구성 , where 조건 parentFolderId, uploadStatus
 		JPAQuery<FileMetadata> query = queryFactory.selectFrom(fileMetadata)
 			.where(fileMetadata.parentFolderId.eq(parentId))
-			.where(fileMetadata.uploadStatus.eq(UploadStatus.SUCCESS))
-			.where(fileMetadata.id.gt(cursorId));
+			.where(fileMetadata.uploadStatus.eq(UploadStatus.SUCCESS));
 
 		// 정렬 조건 적용
+		BooleanExpression cursorCondition;
 		OrderSpecifier<?> orderSpecifier;
 		switch (sortBy) {
-			case CREATED_AT ->
-				orderSpecifier = direction.isAscending() ? fileMetadata.createdAt.asc() : fileMetadata.createdAt.desc();
-			case FOLDER_SIZE ->
-				orderSpecifier = direction.isAscending() ? fileMetadata.size.asc() : fileMetadata.size.desc();
-			default ->
-				// 기본적으로 ID로 정렬
+			case CREATED_AT:
+
+				if (direction.isAscending()) {
+					cursorCondition = fileMetadata.createdAt.gt(dateTime)
+						.or(fileMetadata.createdAt.eq(dateTime).and(fileMetadata.id.gt(cursorId)));
+					orderSpecifier = fileMetadata.createdAt.asc();
+				} else {
+					cursorCondition = fileMetadata.createdAt.lt(dateTime)
+						.or(fileMetadata.createdAt.eq(dateTime).and(fileMetadata.id.gt(cursorId)));
+					orderSpecifier = fileMetadata.createdAt.desc();
+				}
+				break;
+			case DATA_SIZE:
+				if (direction.isAscending()) {
+					cursorCondition = fileMetadata.size.gt(size)
+						.or(fileMetadata.size.eq(size).and(fileMetadata.id.gt(cursorId)));
+					orderSpecifier = fileMetadata.size.asc();
+				} else {
+					cursorCondition = fileMetadata.size.lt(size)
+						.or(fileMetadata.size.eq(size).and(fileMetadata.id.gt(cursorId)));
+					orderSpecifier = fileMetadata.size.desc();
+				}
+				break;
+			default:
+				// 조건에 없는 Enum 값이 들어오면 id 기준 정렬
+				cursorCondition = fileMetadata.id.gt(cursorId);
 				orderSpecifier = fileMetadata.id.asc();
 		}
 
-		// 정렬 조건 추가 (선택된 필드로 정렬 후, ID로 추가 정렬하여 일관성 유지)
+		// 커서 조건 추가
+		query = query.where(cursorCondition);
+
+		// 정렬 조건이 같으면 id 기준으로 정렬
 		query = query.orderBy(orderSpecifier, fileMetadata.id.asc());
-		// limit 추가
+
+		// limit 제한 추가
 		query.limit(limit);
 
 		return query.fetch();

--- a/src/main/java/com/woowacamp/storage/domain/file/repository/FileCustomRepositoryImpl.java
+++ b/src/main/java/com/woowacamp/storage/domain/file/repository/FileCustomRepositoryImpl.java
@@ -21,7 +21,7 @@ public class FileCustomRepositoryImpl implements FileCustomRepository {
 	private static final QFileMetadata fileMetadata = QFileMetadata.fileMetadata;
 	private final JPAQueryFactory queryFactory;
 
-	public List<FileMetadata> findAllByParentIdAndCursorIdOrderBy(long parentId, long cursorId,
+	public List<FileMetadata> selectFilesWithPagination(long parentId, long cursorId,
 		FolderContentsSortField sortBy, Sort.Direction direction, int size) {
 
 		// 기본 쿼리 구성 , where 조건 parentFolderId, uploadStatus
@@ -33,13 +33,11 @@ public class FileCustomRepositoryImpl implements FileCustomRepository {
 		// 정렬 조건 적용
 		OrderSpecifier<?> orderSpecifier;
 		switch (sortBy) {
-			case CREATED_AT:
+			case CREATED_AT ->
 				orderSpecifier = direction.isAscending() ? fileMetadata.createdAt.asc() : fileMetadata.createdAt.desc();
-				break;
-			case FOLDER_SIZE:
+			case FOLDER_SIZE ->
 				orderSpecifier = direction.isAscending() ? fileMetadata.size.asc() : fileMetadata.size.desc();
-				break;
-			default:
+			default ->
 				// 기본적으로 ID로 정렬
 				orderSpecifier = fileMetadata.id.asc();
 		}

--- a/src/main/java/com/woowacamp/storage/domain/file/repository/FileMetadataJpaRepository.java
+++ b/src/main/java/com/woowacamp/storage/domain/file/repository/FileMetadataJpaRepository.java
@@ -4,5 +4,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 import com.woowacamp.storage.domain.file.entity.FileMetadata;
 
-public interface FileMetadataRepository extends JpaRepository<FileMetadata, Long>, FileCustomRepository {
+public interface FileMetadataJpaRepository extends JpaRepository<FileMetadata, Long> {
 }

--- a/src/main/java/com/woowacamp/storage/domain/file/repository/FileMetadataRepository.java
+++ b/src/main/java/com/woowacamp/storage/domain/file/repository/FileMetadataRepository.java
@@ -3,7 +3,6 @@ package com.woowacamp.storage.domain.file.repository;
 import java.util.List;
 
 import org.springframework.data.domain.Pageable;
-import org.springframework.data.domain.Sort;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 

--- a/src/main/java/com/woowacamp/storage/domain/file/repository/FileMetadataRepository.java
+++ b/src/main/java/com/woowacamp/storage/domain/file/repository/FileMetadataRepository.java
@@ -2,13 +2,15 @@ package com.woowacamp.storage.domain.file.repository;
 
 import java.util.List;
 
-import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 import com.woowacamp.storage.domain.file.entity.FileMetadata;
 import com.woowacamp.storage.global.constant.UploadStatus;
 
 public interface FileMetadataRepository extends JpaRepository<FileMetadata, Long> {
-	List<FileMetadata> findByParentFolderIdAndIdGreaterThanAndUploadStatus(Long folderId, Long cursorId,
-		UploadStatus uploadStatus, PageRequest of);
+	@Query(value = "SELECT f FROM FileMetadata  f WHERE f.parentFolderId = :folderId AND f.id > :cursorId AND f.uploadStatus = :uploadStatus ")
+	List<FileMetadata> findFilesByCursor(Long folderId, Long cursorId, UploadStatus uploadStatus, Pageable pageable);
 }

--- a/src/main/java/com/woowacamp/storage/domain/file/repository/FileMetadataRepository.java
+++ b/src/main/java/com/woowacamp/storage/domain/file/repository/FileMetadataRepository.java
@@ -2,16 +2,13 @@ package com.woowacamp.storage.domain.file.repository;
 
 import java.util.List;
 
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
 
 import com.woowacamp.storage.domain.file.entity.FileMetadata;
 import com.woowacamp.storage.global.constant.UploadStatus;
 
 public interface FileMetadataRepository extends JpaRepository<FileMetadata, Long> {
-	Page<FileMetadata> findFilesByParentFolderIdAndUploadStatusIs(long folderId, UploadStatus uploadStatus, Pageable pageable);
-
-	int countByParentFolderId(long folderId);
+	List<FileMetadata> findByParentFolderIdAndIdGreaterThanAndUploadStatus(Long folderId, Long cursorId,
+		UploadStatus uploadStatus, PageRequest of);
 }

--- a/src/main/java/com/woowacamp/storage/domain/file/repository/FileMetadataRepository.java
+++ b/src/main/java/com/woowacamp/storage/domain/file/repository/FileMetadataRepository.java
@@ -1,8 +1,17 @@
 package com.woowacamp.storage.domain.file.repository;
 
+import java.util.List;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 import com.woowacamp.storage.domain.file.entity.FileMetadata;
+import com.woowacamp.storage.global.constant.UploadStatus;
 
 public interface FileMetadataRepository extends JpaRepository<FileMetadata, Long> {
+	Page<FileMetadata> findFilesByParentFolderIdAndUploadStatusIs(long folderId, UploadStatus uploadStatus, Pageable pageable);
+
+	int countByParentFolderId(long folderId);
 }

--- a/src/main/java/com/woowacamp/storage/domain/folder/controller/FolderController.java
+++ b/src/main/java/com/woowacamp/storage/domain/folder/controller/FolderController.java
@@ -1,17 +1,16 @@
 package com.woowacamp.storage.domain.folder.controller;
 
-import org.springframework.data.domain.Sort;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
-import com.woowacamp.storage.domain.folder.dto.CursorType;
 import com.woowacamp.storage.domain.folder.dto.FolderContentsDto;
-import com.woowacamp.storage.domain.folder.dto.FolderContentsSortField;
+import com.woowacamp.storage.domain.folder.dto.GetFolderContentsRequestParams;
 import com.woowacamp.storage.domain.folder.service.FolderService;
 
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 
 @RestController
@@ -21,13 +20,13 @@ public class FolderController {
 	private final FolderService folderService;
 
 	@GetMapping("/{folderId}")
-	public FolderContentsDto getFolderContents(@PathVariable Long folderId, @RequestParam Long userId,
-		@RequestParam Long cursorId, @RequestParam CursorType cursorType, @RequestParam(defaultValue = "100") int size,
-		@RequestParam(required = false, defaultValue = "createdAt") FolderContentsSortField sortBy,
-		@RequestParam(required = false, defaultValue = "DESC") Sort.Direction sortDirection) {
+	public FolderContentsDto getFolderContents(
+		@PathVariable Long folderId,
+		@Valid @ModelAttribute GetFolderContentsRequestParams request) {
 
-		folderService.checkFolderOwnedBy(folderId, userId);
+		folderService.checkFolderOwnedBy(folderId, request.userId());
 
-		return folderService.getFolderContents(folderId, cursorId, cursorType, size, sortBy, sortDirection);
+		return folderService.getFolderContents(folderId, request.cursorId(), request.cursorType(), request.size(),
+			request.sortBy(), request.sortDirection());
 	}
 }

--- a/src/main/java/com/woowacamp/storage/domain/folder/controller/FolderController.java
+++ b/src/main/java/com/woowacamp/storage/domain/folder/controller/FolderController.java
@@ -1,8 +1,6 @@
 package com.woowacamp.storage.domain.folder.controller;
 
-import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Sort;
-import org.springframework.data.web.PageableDefault;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -21,11 +19,14 @@ public class FolderController {
 	private final FolderService folderService;
 
 	@GetMapping("/{folderId}")
-	private FolderContentsDto getFolderContents(
-		@PathVariable Long folderId,
-		@RequestParam Long userId,
-		@PageableDefault(size = 100, page = 0, sort = "createdAt", direction = Sort.Direction.DESC) @RequestParam PageRequest pageRequest) {
+	public FolderContentsDto getFolderContents(@PathVariable Long folderId, @RequestParam Long userId,
+		@RequestParam(required = false) Long cursorId,
+		@RequestParam(required = false, defaultValue = "Folder") String cursorType,
+		@RequestParam(defaultValue = "100") int size, @RequestParam(defaultValue = "createdAt") String sortBy,
+		@RequestParam(defaultValue = "DESC") Sort.Direction sortDirection) {
+
 		folderService.checkFolderOwnedBy(folderId, userId);
-		return folderService.getFolderContents(folderId, pageRequest);
+
+		return folderService.getFolderContents(folderId, cursorId, cursorType, size, sortBy, sortDirection);
 	}
 }

--- a/src/main/java/com/woowacamp/storage/domain/folder/controller/FolderController.java
+++ b/src/main/java/com/woowacamp/storage/domain/folder/controller/FolderController.java
@@ -29,6 +29,6 @@ public class FolderController {
 
 		folderService.checkFolderOwnedBy(folderId, userId);
 
-		return folderService.getFolderContents(folderId, cursorId, cursorType, size, sortBy, sortDirection);
+		return folderService.getFolderContents(folderId, cursorId, cursorType, size, sortBy.getValue(), sortDirection);
 	}
 }

--- a/src/main/java/com/woowacamp/storage/domain/folder/controller/FolderController.java
+++ b/src/main/java/com/woowacamp/storage/domain/folder/controller/FolderController.java
@@ -7,6 +7,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.woowacamp.storage.domain.folder.dto.CursorType;
 import com.woowacamp.storage.domain.folder.dto.FolderContentsDto;
 import com.woowacamp.storage.domain.folder.dto.FolderContentsSortField;
 import com.woowacamp.storage.domain.folder.service.FolderService;
@@ -21,14 +22,12 @@ public class FolderController {
 
 	@GetMapping("/{folderId}")
 	public FolderContentsDto getFolderContents(@PathVariable Long folderId, @RequestParam Long userId,
-		@RequestParam(required = false) Long cursorId,
-		@RequestParam(required = false, defaultValue = "Folder") String cursorType,
-		@RequestParam(defaultValue = "100") int size,
-		@RequestParam(defaultValue = "createdAt") FolderContentsSortField sortBy,
-		@RequestParam(defaultValue = "DESC") Sort.Direction sortDirection) {
+		@RequestParam Long cursorId, @RequestParam CursorType cursorType, @RequestParam(defaultValue = "100") int size,
+		@RequestParam(required = false, defaultValue = "createdAt") FolderContentsSortField sortBy,
+		@RequestParam(required = false, defaultValue = "DESC") Sort.Direction sortDirection) {
 
 		folderService.checkFolderOwnedBy(folderId, userId);
 
-		return folderService.getFolderContents(folderId, cursorId, cursorType, size, sortBy.getValue(), sortDirection);
+		return folderService.getFolderContents(folderId, cursorId, cursorType, size, sortBy, sortDirection);
 	}
 }

--- a/src/main/java/com/woowacamp/storage/domain/folder/controller/FolderController.java
+++ b/src/main/java/com/woowacamp/storage/domain/folder/controller/FolderController.java
@@ -1,12 +1,31 @@
 package com.woowacamp.storage.domain.folder.controller;
 
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+
+import com.woowacamp.storage.domain.folder.dto.FolderContentsDto;
+import com.woowacamp.storage.domain.folder.service.FolderService;
 
 import lombok.RequiredArgsConstructor;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("")
+@RequestMapping("/api/v1/folders")
 public class FolderController {
+	private final FolderService folderService;
+
+	@GetMapping("/{folderId}")
+	private FolderContentsDto getFolderContents(
+		@PathVariable Long folderId,
+		@RequestParam Long userId,
+		@PageableDefault(size = 100, page = 0, sort = "createdAt", direction = Sort.Direction.DESC) @RequestParam PageRequest pageRequest) {
+		folderService.checkFolderOwnedBy(folderId, userId);
+		return folderService.getFolderContents(folderId, pageRequest);
+	}
 }

--- a/src/main/java/com/woowacamp/storage/domain/folder/controller/FolderController.java
+++ b/src/main/java/com/woowacamp/storage/domain/folder/controller/FolderController.java
@@ -20,13 +20,12 @@ public class FolderController {
 	private final FolderService folderService;
 
 	@GetMapping("/{folderId}")
-	public FolderContentsDto getFolderContents(
-		@PathVariable Long folderId,
+	public FolderContentsDto getFolderContents(@PathVariable Long folderId,
 		@Valid @ModelAttribute GetFolderContentsRequestParams request) {
 
 		folderService.checkFolderOwnedBy(folderId, request.userId());
 
-		return folderService.getFolderContents(folderId, request.cursorId(), request.cursorType(), request.size(),
-			request.sortBy(), request.sortDirection());
+		return folderService.getFolderContents(folderId, request.cursorId(), request.cursorType(), request.limit(),
+			request.sortBy(), request.sortDirection(), request.localDateTime(), request.size());
 	}
 }

--- a/src/main/java/com/woowacamp/storage/domain/folder/controller/FolderController.java
+++ b/src/main/java/com/woowacamp/storage/domain/folder/controller/FolderController.java
@@ -8,6 +8,7 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.woowacamp.storage.domain.folder.dto.FolderContentsDto;
+import com.woowacamp.storage.domain.folder.dto.FolderContentsSortField;
 import com.woowacamp.storage.domain.folder.service.FolderService;
 
 import lombok.RequiredArgsConstructor;
@@ -22,7 +23,8 @@ public class FolderController {
 	public FolderContentsDto getFolderContents(@PathVariable Long folderId, @RequestParam Long userId,
 		@RequestParam(required = false) Long cursorId,
 		@RequestParam(required = false, defaultValue = "Folder") String cursorType,
-		@RequestParam(defaultValue = "100") int size, @RequestParam(defaultValue = "createdAt") String sortBy,
+		@RequestParam(defaultValue = "100") int size,
+		@RequestParam(defaultValue = "createdAt") FolderContentsSortField sortBy,
 		@RequestParam(defaultValue = "DESC") Sort.Direction sortDirection) {
 
 		folderService.checkFolderOwnedBy(folderId, userId);

--- a/src/main/java/com/woowacamp/storage/domain/folder/dto/CursorType.java
+++ b/src/main/java/com/woowacamp/storage/domain/folder/dto/CursorType.java
@@ -1,0 +1,23 @@
+package com.woowacamp.storage.domain.folder.dto;
+
+import lombok.Getter;
+
+@Getter
+public enum CursorType {
+
+	FOLDER("Folder"), FILE("File");
+	private final String value;
+
+	CursorType(String value) {
+		this.value = value;
+	}
+
+	public static CursorType fromValue(String value) {
+		for (CursorType field : CursorType.values()) {
+			if (field.getValue().equalsIgnoreCase(value)) {
+				return field;
+			}
+		}
+		throw new IllegalArgumentException("Invalid sort field: " + value);
+	}
+}

--- a/src/main/java/com/woowacamp/storage/domain/folder/dto/CursorType.java
+++ b/src/main/java/com/woowacamp/storage/domain/folder/dto/CursorType.java
@@ -1,23 +1,23 @@
 package com.woowacamp.storage.domain.folder.dto;
 
+import java.util.Arrays;
+
+import com.woowacamp.storage.global.error.ErrorCode;
+
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 
 @Getter
+@AllArgsConstructor
 public enum CursorType {
 
 	FOLDER("Folder"), FILE("File");
 	private final String value;
 
-	CursorType(String value) {
-		this.value = value;
-	}
-
 	public static CursorType fromValue(String value) {
-		for (CursorType field : CursorType.values()) {
-			if (field.getValue().equalsIgnoreCase(value)) {
-				return field;
-			}
-		}
-		throw new IllegalArgumentException("Invalid sort field: " + value);
+		return Arrays.stream(CursorType.values())
+			.filter(type -> type.getValue().equalsIgnoreCase(value))
+			.findFirst()
+			.orElseThrow(ErrorCode.WRONG_CURSOR_TYPE::baseException);
 	}
 }

--- a/src/main/java/com/woowacamp/storage/domain/folder/dto/CursorTypeConverter.java
+++ b/src/main/java/com/woowacamp/storage/domain/folder/dto/CursorTypeConverter.java
@@ -1,0 +1,12 @@
+package com.woowacamp.storage.domain.folder.dto;
+
+import org.springframework.core.convert.converter.Converter;
+import org.springframework.stereotype.Component;
+
+@Component
+public class CursorTypeConverter implements Converter<String, CursorType> {
+	@Override
+	public CursorType convert(String source) {
+		return CursorType.fromValue(source);
+	}
+}

--- a/src/main/java/com/woowacamp/storage/domain/folder/dto/FolderContentsDto.java
+++ b/src/main/java/com/woowacamp/storage/domain/folder/dto/FolderContentsDto.java
@@ -5,7 +5,6 @@ import java.util.List;
 import com.woowacamp.storage.domain.file.entity.FileMetadata;
 import com.woowacamp.storage.domain.folder.entity.FolderMetadata;
 
-public record FolderContentsDto(List<FolderMetadata> folderMetadataList, List<FileMetadata> fileMetadataList,
-								Long nextCursorId, String nextCursorType) {
+public record FolderContentsDto(List<FolderMetadata> folderMetadataList, List<FileMetadata> fileMetadataList) {
 }
 

--- a/src/main/java/com/woowacamp/storage/domain/folder/dto/FolderContentsDto.java
+++ b/src/main/java/com/woowacamp/storage/domain/folder/dto/FolderContentsDto.java
@@ -1,0 +1,18 @@
+package com.woowacamp.storage.domain.folder.dto;
+
+import java.util.List;
+
+import com.woowacamp.storage.domain.file.entity.FileMetadata;
+import com.woowacamp.storage.domain.folder.entity.FolderMetadata;
+
+public record FolderContentsDto(
+	int totalPages,
+	int currentPage,
+	int totalElements,
+	int pageSize,
+	int currentElements,
+	FolderMetadata folder,
+	List<FolderMetadata> subFolders,
+	List<FileMetadata> files) {
+}
+

--- a/src/main/java/com/woowacamp/storage/domain/folder/dto/FolderContentsDto.java
+++ b/src/main/java/com/woowacamp/storage/domain/folder/dto/FolderContentsDto.java
@@ -5,14 +5,7 @@ import java.util.List;
 import com.woowacamp.storage.domain.file.entity.FileMetadata;
 import com.woowacamp.storage.domain.folder.entity.FolderMetadata;
 
-public record FolderContentsDto(
-	int totalPages,
-	int currentPage,
-	int totalElements,
-	int pageSize,
-	int currentElements,
-	FolderMetadata folder,
-	List<FolderMetadata> subFolders,
-	List<FileMetadata> files) {
+public record FolderContentsDto(List<FolderMetadata> folderMetadataList, List<FileMetadata> fileMetadataList,
+								Long nextCursorId, String nextCursorType) {
 }
 

--- a/src/main/java/com/woowacamp/storage/domain/folder/dto/FolderContentsSortField.java
+++ b/src/main/java/com/woowacamp/storage/domain/folder/dto/FolderContentsSortField.java
@@ -1,22 +1,22 @@
 package com.woowacamp.storage.domain.folder.dto;
 
+import java.util.Arrays;
+
+import com.woowacamp.storage.global.error.ErrorCode;
+
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 
 @Getter
+@AllArgsConstructor
 public enum FolderContentsSortField {
 	CREATED_AT("createdAt"), FOLDER_SIZE("size");
 	private final String value;
 
-	FolderContentsSortField(String value) {
-		this.value = value;
-	}
-
 	public static FolderContentsSortField fromValue(String value) {
-		for (FolderContentsSortField field : FolderContentsSortField.values()) {
-			if (field.getValue().equalsIgnoreCase(value)) {
-				return field;
-			}
-		}
-		throw new IllegalArgumentException("Invalid sort field: " + value);
+		return Arrays.stream(FolderContentsSortField.values())
+			.filter(type -> type.getValue().equalsIgnoreCase(value))
+			.findFirst()
+			.orElseThrow(ErrorCode.WRONG_FOLDER_CONTENTS_SORT_FIELD::baseException);
 	}
 }

--- a/src/main/java/com/woowacamp/storage/domain/folder/dto/FolderContentsSortField.java
+++ b/src/main/java/com/woowacamp/storage/domain/folder/dto/FolderContentsSortField.java
@@ -1,0 +1,22 @@
+package com.woowacamp.storage.domain.folder.dto;
+
+import lombok.Getter;
+
+@Getter
+public enum FolderContentsSortField {
+	CREATED_AT("createdAt"), FOLDER_SIZE("size");
+	private final String value;
+
+	FolderContentsSortField(String value) {
+		this.value = value;
+	}
+
+	public static FolderContentsSortField fromValue(String value) {
+		for (FolderContentsSortField field : FolderContentsSortField.values()) {
+			if (field.getValue().equalsIgnoreCase(value)) {
+				return field;
+			}
+		}
+		throw new IllegalArgumentException("Invalid sort field: " + value);
+	}
+}

--- a/src/main/java/com/woowacamp/storage/domain/folder/dto/FolderContentsSortField.java
+++ b/src/main/java/com/woowacamp/storage/domain/folder/dto/FolderContentsSortField.java
@@ -10,7 +10,7 @@ import lombok.Getter;
 @Getter
 @AllArgsConstructor
 public enum FolderContentsSortField {
-	CREATED_AT("createdAt"), FOLDER_SIZE("size");
+	CREATED_AT("createdAt"), DATA_SIZE("size");
 	private final String value;
 
 	public static FolderContentsSortField fromValue(String value) {

--- a/src/main/java/com/woowacamp/storage/domain/folder/dto/FolderContentsSortFieldConverter.java
+++ b/src/main/java/com/woowacamp/storage/domain/folder/dto/FolderContentsSortFieldConverter.java
@@ -1,0 +1,12 @@
+package com.woowacamp.storage.domain.folder.dto;
+
+import org.springframework.core.convert.converter.Converter;
+import org.springframework.stereotype.Component;
+
+@Component
+public class FolderContentsSortFieldConverter implements Converter<String, FolderContentsSortField> {
+	@Override
+	public FolderContentsSortField convert(String source) {
+		return FolderContentsSortField.fromValue(source);
+	}
+}

--- a/src/main/java/com/woowacamp/storage/domain/folder/dto/GetFolderContentsRequestParams.java
+++ b/src/main/java/com/woowacamp/storage/domain/folder/dto/GetFolderContentsRequestParams.java
@@ -1,5 +1,7 @@
 package com.woowacamp.storage.domain.folder.dto;
 
+import java.time.LocalDateTime;
+
 import org.springframework.data.domain.Sort;
 
 import jakarta.validation.constraints.Max;
@@ -7,21 +9,17 @@ import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Positive;
 
-public record GetFolderContentsRequestParams(
-	@NotNull @Positive Long userId,
-	@NotNull @Positive Long cursorId,
-	@NotNull CursorType cursorType,
-	@Min(0) @Max(MAX_SIZE) int size,
-	FolderContentsSortField sortBy,
-	Sort.Direction sortDirection
-) {
+public record GetFolderContentsRequestParams(@NotNull @Positive Long userId, @NotNull @Positive Long cursorId,
+											 @NotNull CursorType cursorType, @Min(0) @Max(MAX_SIZE) int limit,
+											 FolderContentsSortField sortBy, Sort.Direction sortDirection,
+											 LocalDateTime localDateTime, Long size) {
 	private static final int MAX_SIZE = 1000;
 	private static final int DEFAULT_SIZE = 100;
 
-	// 기본 생성자 정의 (모든 필드에 대한 기본값 설정)
+	// 기본 생성자 정의
 	public GetFolderContentsRequestParams {
-		if (size == 0) {
-			size = DEFAULT_SIZE;
+		if (limit == 0) {
+			limit = DEFAULT_SIZE;
 		}
 		if (sortBy == null) {
 			sortBy = FolderContentsSortField.CREATED_AT;
@@ -29,6 +27,28 @@ public record GetFolderContentsRequestParams(
 		if (sortDirection == null) {
 			sortDirection = Sort.Direction.DESC;
 		}
+
+		if (isFirstPage(localDateTime, size)) {
+			switch (sortBy) {
+				case CREATED_AT:
+					if (sortDirection.isAscending()) {
+						localDateTime = LocalDateTime.of(1970, 1, 1, 0, 0);
+					} else {
+						localDateTime = LocalDateTime.now().plusYears(1000);
+					}
+				case FOLDER_SIZE:
+					if (sortDirection.isAscending()) {
+						size = Long.MAX_VALUE;
+					} else {
+						size = 0L;
+					}
+				default:
+					throw new IllegalArgumentException("Unsupported sortBy option: " + sortBy);
+			}
+		}
 	}
-	// 필요한 경우 추가 메서드를 여기에 정의할 수 있습니다.
+
+	private boolean isFirstPage(LocalDateTime localDateTime, Long size) {
+		return localDateTime == null || size == null;
+	}
 }

--- a/src/main/java/com/woowacamp/storage/domain/folder/dto/GetFolderContentsRequestParams.java
+++ b/src/main/java/com/woowacamp/storage/domain/folder/dto/GetFolderContentsRequestParams.java
@@ -1,0 +1,33 @@
+package com.woowacamp.storage.domain.folder.dto;
+
+import org.springframework.data.domain.Sort;
+
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
+import jakarta.validation.constraints.Size;
+
+public record GetFolderContentsRequestParams(
+	@Positive Long userId,
+	@Positive Long cursorId,
+	@NotNull CursorType cursorType,
+	@Size(min = 0, max = MAX_SIZE) int size,
+	FolderContentsSortField sortBy,
+	Sort.Direction sortDirection
+) {
+	private static final int MAX_SIZE = 1000;
+	private static final int DEFAULT_SIZE = 100;
+
+	// 기본 생성자 정의 (모든 필드에 대한 기본값 설정)
+	public GetFolderContentsRequestParams {
+		if (size == 0) {
+			size = DEFAULT_SIZE;
+		}
+		if (sortBy == null) {
+			sortBy = FolderContentsSortField.CREATED_AT;
+		}
+		if (sortDirection == null) {
+			sortDirection = Sort.Direction.DESC;
+		}
+	}
+	// 필요한 경우 추가 메서드를 여기에 정의할 수 있습니다.
+}

--- a/src/main/java/com/woowacamp/storage/domain/folder/dto/GetFolderContentsRequestParams.java
+++ b/src/main/java/com/woowacamp/storage/domain/folder/dto/GetFolderContentsRequestParams.java
@@ -8,8 +8,8 @@ import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Positive;
 
 public record GetFolderContentsRequestParams(
-	@Positive Long userId,
-	@Positive Long cursorId,
+	@NotNull @Positive Long userId,
+	@NotNull @Positive Long cursorId,
 	@NotNull CursorType cursorType,
 	@Min(0) @Max(MAX_SIZE) int size,
 	FolderContentsSortField sortBy,

--- a/src/main/java/com/woowacamp/storage/domain/folder/dto/GetFolderContentsRequestParams.java
+++ b/src/main/java/com/woowacamp/storage/domain/folder/dto/GetFolderContentsRequestParams.java
@@ -2,15 +2,16 @@ package com.woowacamp.storage.domain.folder.dto;
 
 import org.springframework.data.domain.Sort;
 
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Positive;
-import jakarta.validation.constraints.Size;
 
 public record GetFolderContentsRequestParams(
 	@Positive Long userId,
 	@Positive Long cursorId,
 	@NotNull CursorType cursorType,
-	@Size(min = 0, max = MAX_SIZE) int size,
+	@Min(0) @Max(MAX_SIZE) int size,
 	FolderContentsSortField sortBy,
 	Sort.Direction sortDirection
 ) {

--- a/src/main/java/com/woowacamp/storage/domain/folder/dto/GetFolderContentsRequestParams.java
+++ b/src/main/java/com/woowacamp/storage/domain/folder/dto/GetFolderContentsRequestParams.java
@@ -36,7 +36,7 @@ public record GetFolderContentsRequestParams(@NotNull @Positive Long userId, @No
 					} else {
 						localDateTime = LocalDateTime.now().plusYears(1000);
 					}
-				case FOLDER_SIZE:
+				case DATA_SIZE:
 					if (sortDirection.isAscending()) {
 						size = Long.MAX_VALUE;
 					} else {

--- a/src/main/java/com/woowacamp/storage/domain/folder/dto/GetFolderContentsRequestParams.java
+++ b/src/main/java/com/woowacamp/storage/domain/folder/dto/GetFolderContentsRequestParams.java
@@ -36,12 +36,14 @@ public record GetFolderContentsRequestParams(@NotNull @Positive Long userId, @No
 					} else {
 						localDateTime = LocalDateTime.now().plusYears(1000);
 					}
+					break;
 				case DATA_SIZE:
 					if (sortDirection.isAscending()) {
 						size = Long.MAX_VALUE;
 					} else {
 						size = 0L;
 					}
+					break;
 				default:
 					throw new IllegalArgumentException("Unsupported sortBy option: " + sortBy);
 			}

--- a/src/main/java/com/woowacamp/storage/domain/folder/entity/FolderMetadata.java
+++ b/src/main/java/com/woowacamp/storage/domain/folder/entity/FolderMetadata.java
@@ -7,6 +7,7 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.Index;
 import jakarta.persistence.Table;
 import jakarta.validation.constraints.NotNull;
 import lombok.AccessLevel;
@@ -15,9 +16,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
-@Table(
-	name = "folder_metadata"
-)
+@Table(name = "folder_metadata", indexes = @Index(name = "folder_idx_parent_folder_id", columnList = "parent_folder_id"))
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class FolderMetadata {
@@ -50,6 +49,9 @@ public class FolderMetadata {
 	@Column(name = "upload_folder_name", columnDefinition = "VARCHAR(100) NOT NULL")
 	@NotNull
 	private String uploadFolderName;
+
+	@Column(name = "folder_size", columnDefinition = "BIGINT NOT NULL DEFAULT 0")
+	private long folderSize;
 
 	@Builder
 	private FolderMetadata(Long id, Long rootId, Long ownerId, Long creatorId, LocalDateTime createdAt,

--- a/src/main/java/com/woowacamp/storage/domain/folder/entity/FolderMetadata.java
+++ b/src/main/java/com/woowacamp/storage/domain/folder/entity/FolderMetadata.java
@@ -51,11 +51,11 @@ public class FolderMetadata {
 	private String uploadFolderName;
 
 	@Column(name = "folder_size", columnDefinition = "BIGINT NOT NULL DEFAULT 0")
-	private long folderSize;
+	private long size;
 
 	@Builder
 	private FolderMetadata(Long id, Long rootId, Long ownerId, Long creatorId, LocalDateTime createdAt,
-		LocalDateTime updatedAt, Long parentFolderId, String uploadFolderName) {
+		LocalDateTime updatedAt, Long parentFolderId, String uploadFolderName, long size) {
 		this.id = id;
 		this.rootId = rootId;
 		this.ownerId = ownerId;
@@ -64,6 +64,7 @@ public class FolderMetadata {
 		this.updatedAt = updatedAt;
 		this.parentFolderId = parentFolderId;
 		this.uploadFolderName = uploadFolderName;
+		this.size = size;
 	}
 
 	public void initOwnerId(Long ownerId) {

--- a/src/main/java/com/woowacamp/storage/domain/folder/entity/FolderMetadata.java
+++ b/src/main/java/com/woowacamp/storage/domain/folder/entity/FolderMetadata.java
@@ -16,7 +16,10 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
-@Table(name = "folder_metadata", indexes = @Index(name = "folder_idx_parent_folder_id", columnList = "parent_folder_id"))
+@Table(name = "folder_metadata", indexes = {
+	@Index(name = "folder_idx_parent_folder_id_size", columnList = "parent_folder_id, created_at"),
+	@Index(name = "folder_idx_parent_folder_id_created_at", columnList = "parent_folder_id, folder_size")
+})
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class FolderMetadata {

--- a/src/main/java/com/woowacamp/storage/domain/folder/repository/FolderCustomRepository.java
+++ b/src/main/java/com/woowacamp/storage/domain/folder/repository/FolderCustomRepository.java
@@ -1,0 +1,13 @@
+package com.woowacamp.storage.domain.folder.repository;
+
+import java.util.List;
+
+import org.springframework.data.domain.Sort;
+
+import com.woowacamp.storage.domain.folder.dto.FolderContentsSortField;
+import com.woowacamp.storage.domain.folder.entity.FolderMetadata;
+
+public interface FolderCustomRepository {
+	List<FolderMetadata> findAllByParentIdAndCursorIdOrderBy(long parentId, long cursorId,
+		FolderContentsSortField sortBy, Sort.Direction direction, int limit);
+}

--- a/src/main/java/com/woowacamp/storage/domain/folder/repository/FolderCustomRepository.java
+++ b/src/main/java/com/woowacamp/storage/domain/folder/repository/FolderCustomRepository.java
@@ -8,6 +8,6 @@ import com.woowacamp.storage.domain.folder.dto.FolderContentsSortField;
 import com.woowacamp.storage.domain.folder.entity.FolderMetadata;
 
 public interface FolderCustomRepository {
-	List<FolderMetadata> findAllByParentIdAndCursorIdOrderBy(long parentId, long cursorId,
+	List<FolderMetadata> selectFoldersWithPagination(long parentId, long cursorId,
 		FolderContentsSortField sortBy, Sort.Direction direction, int limit);
 }

--- a/src/main/java/com/woowacamp/storage/domain/folder/repository/FolderCustomRepository.java
+++ b/src/main/java/com/woowacamp/storage/domain/folder/repository/FolderCustomRepository.java
@@ -1,5 +1,6 @@
 package com.woowacamp.storage.domain.folder.repository;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 import org.springframework.data.domain.Sort;
@@ -8,6 +9,6 @@ import com.woowacamp.storage.domain.folder.dto.FolderContentsSortField;
 import com.woowacamp.storage.domain.folder.entity.FolderMetadata;
 
 public interface FolderCustomRepository {
-	List<FolderMetadata> selectFoldersWithPagination(long parentId, long cursorId,
-		FolderContentsSortField sortBy, Sort.Direction direction, int limit);
+	public List<FolderMetadata> selectFoldersWithPagination(long parentId, long cursorId,
+		FolderContentsSortField sortBy, Sort.Direction direction, int limit, LocalDateTime dateTime, Long size);
 }

--- a/src/main/java/com/woowacamp/storage/domain/folder/repository/FolderCustomRepositoryImpl.java
+++ b/src/main/java/com/woowacamp/storage/domain/folder/repository/FolderCustomRepositoryImpl.java
@@ -18,18 +18,15 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class FolderCustomRepositoryImpl implements FolderCustomRepository {
 
+	private static final QFolderMetadata folderMetadata = QFolderMetadata.folderMetadata;
 	private final JPAQueryFactory queryFactory;
 
 	public List<FolderMetadata> selectFoldersWithPagination(long parentId, long cursorId,
 		FolderContentsSortField sortBy, Sort.Direction direction, int limit, LocalDateTime dateTime, Long size) {
-		QFolderMetadata folderMetadata = QFolderMetadata.folderMetadata;
 
 		// 기본 쿼리 구성
 		JPAQuery<FolderMetadata> query = queryFactory.selectFrom(folderMetadata)
 			.where(folderMetadata.parentFolderId.eq(parentId));
-
-		// 서브쿼리로 cursorId에 해당하는 생성 시간 또는 폴더 크기 가져오기
-		QFolderMetadata cursorFolder = new QFolderMetadata("cursorFolder");
 
 		// 커서 조건 및 정렬 조건 설정
 		BooleanExpression cursorCondition;
@@ -47,7 +44,7 @@ public class FolderCustomRepositoryImpl implements FolderCustomRepository {
 					orderSpecifier = folderMetadata.createdAt.desc();
 				}
 				break;
-			case FOLDER_SIZE:
+			case DATA_SIZE:
 				if (direction.isAscending()) {
 					cursorCondition = folderMetadata.size.gt(size)
 						.or(folderMetadata.size.eq(size).and(folderMetadata.id.gt(cursorId)));

--- a/src/main/java/com/woowacamp/storage/domain/folder/repository/FolderCustomRepositoryImpl.java
+++ b/src/main/java/com/woowacamp/storage/domain/folder/repository/FolderCustomRepositoryImpl.java
@@ -1,0 +1,53 @@
+package com.woowacamp.storage.domain.folder.repository;
+
+import java.util.List;
+
+import org.springframework.data.domain.Sort;
+
+import com.querydsl.core.types.OrderSpecifier;
+import com.querydsl.jpa.impl.JPAQuery;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.woowacamp.storage.domain.folder.dto.FolderContentsSortField;
+import com.woowacamp.storage.domain.folder.entity.FolderMetadata;
+import com.woowacamp.storage.domain.folder.entity.QFolderMetadata;
+
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public class FolderCustomRepositoryImpl implements FolderCustomRepository {
+
+	private final JPAQueryFactory queryFactory;
+
+	public List<FolderMetadata> findAllByParentIdAndCursorIdOrderBy(long parentId, long cursorId,
+		FolderContentsSortField sortBy, Sort.Direction direction, int size) {
+		QFolderMetadata folderMetadata = QFolderMetadata.folderMetadata;
+
+		// 기본 쿼리 구성 , where 조건 parentFolderId, uploadStatus
+		JPAQuery<FolderMetadata> query = queryFactory.selectFrom(folderMetadata)
+			.where(folderMetadata.parentFolderId.eq(parentId))
+			.where(folderMetadata.id.gt(cursorId));
+
+		// 정렬 조건 적용
+		OrderSpecifier<?> orderSpecifier;
+
+		switch (sortBy) {
+			case CREATED_AT:
+				orderSpecifier =
+					direction.isAscending() ? folderMetadata.createdAt.asc() : folderMetadata.createdAt.desc();
+				break;
+			case FOLDER_SIZE:
+				orderSpecifier = direction.isAscending() ? folderMetadata.size.asc() : folderMetadata.size.desc();
+				break;
+			default:
+				// 기본적으로 ID로 정렬
+				orderSpecifier = folderMetadata.id.asc();
+		}
+
+		// 정렬 조건 추가 (선택된 필드로 정렬 후, ID로 추가 정렬하여 일관성 유지)
+		query = query.orderBy(orderSpecifier, folderMetadata.id.asc());
+		// size 추가
+		query.limit(size);
+
+		return query.fetch();
+	}
+}

--- a/src/main/java/com/woowacamp/storage/domain/folder/repository/FolderCustomRepositoryImpl.java
+++ b/src/main/java/com/woowacamp/storage/domain/folder/repository/FolderCustomRepositoryImpl.java
@@ -18,7 +18,7 @@ public class FolderCustomRepositoryImpl implements FolderCustomRepository {
 
 	private final JPAQueryFactory queryFactory;
 
-	public List<FolderMetadata> findAllByParentIdAndCursorIdOrderBy(long parentId, long cursorId,
+	public List<FolderMetadata> selectFoldersWithPagination(long parentId, long cursorId,
 		FolderContentsSortField sortBy, Sort.Direction direction, int size) {
 		QFolderMetadata folderMetadata = QFolderMetadata.folderMetadata;
 
@@ -29,16 +29,12 @@ public class FolderCustomRepositoryImpl implements FolderCustomRepository {
 
 		// 정렬 조건 적용
 		OrderSpecifier<?> orderSpecifier;
-
 		switch (sortBy) {
-			case CREATED_AT:
-				orderSpecifier =
-					direction.isAscending() ? folderMetadata.createdAt.asc() : folderMetadata.createdAt.desc();
-				break;
-			case FOLDER_SIZE:
+			case CREATED_AT -> orderSpecifier =
+				direction.isAscending() ? folderMetadata.createdAt.asc() : folderMetadata.createdAt.desc();
+			case FOLDER_SIZE ->
 				orderSpecifier = direction.isAscending() ? folderMetadata.size.asc() : folderMetadata.size.desc();
-				break;
-			default:
+			default ->
 				// 기본적으로 ID로 정렬
 				orderSpecifier = folderMetadata.id.asc();
 		}

--- a/src/main/java/com/woowacamp/storage/domain/folder/repository/FolderCustomRepositoryImpl.java
+++ b/src/main/java/com/woowacamp/storage/domain/folder/repository/FolderCustomRepositoryImpl.java
@@ -35,23 +35,23 @@ public class FolderCustomRepositoryImpl implements FolderCustomRepository {
 			case CREATED_AT:
 
 				if (direction.isAscending()) {
-					cursorCondition = folderMetadata.createdAt.gt(dateTime)
-						.or(folderMetadata.createdAt.eq(dateTime).and(folderMetadata.id.gt(cursorId)));
+					cursorCondition = folderMetadata.createdAt.goe(dateTime)
+						.and(folderMetadata.createdAt.gt(dateTime).or(folderMetadata.id.gt(cursorId)));
 					orderSpecifier = folderMetadata.createdAt.asc();
 				} else {
-					cursorCondition = folderMetadata.createdAt.lt(dateTime)
-						.or(folderMetadata.createdAt.eq(dateTime).and(folderMetadata.id.gt(cursorId)));
+					cursorCondition = folderMetadata.createdAt.loe(dateTime)
+						.and(folderMetadata.createdAt.lt(dateTime).or(folderMetadata.id.gt(cursorId)));
 					orderSpecifier = folderMetadata.createdAt.desc();
 				}
 				break;
 			case DATA_SIZE:
 				if (direction.isAscending()) {
-					cursorCondition = folderMetadata.size.gt(size)
-						.or(folderMetadata.size.eq(size).and(folderMetadata.id.gt(cursorId)));
+					cursorCondition = folderMetadata.size.goe(size)
+						.and(folderMetadata.size.gt(size).or(folderMetadata.id.gt(cursorId)));
 					orderSpecifier = folderMetadata.size.asc();
 				} else {
-					cursorCondition = folderMetadata.size.lt(size)
-						.or(folderMetadata.size.eq(size).and(folderMetadata.id.gt(cursorId)));
+					cursorCondition = folderMetadata.size.loe(size)
+						.and(folderMetadata.size.lt(size).or(folderMetadata.id.gt(cursorId)));
 					orderSpecifier = folderMetadata.size.desc();
 				}
 				break;

--- a/src/main/java/com/woowacamp/storage/domain/folder/repository/FolderMetadataJpaRepository.java
+++ b/src/main/java/com/woowacamp/storage/domain/folder/repository/FolderMetadataJpaRepository.java
@@ -1,8 +1,11 @@
 package com.woowacamp.storage.domain.folder.repository;
 
+import java.util.List;
+
+import org.springframework.data.domain.PageRequest;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import com.woowacamp.storage.domain.folder.entity.FolderMetadata;
 
-public interface FolderMetadataRepository extends JpaRepository<FolderMetadata, Long>, FolderCustomRepository {
+public interface FolderMetadataJpaRepository extends JpaRepository<FolderMetadata, Long> {
 }

--- a/src/main/java/com/woowacamp/storage/domain/folder/repository/FolderMetadataRepository.java
+++ b/src/main/java/com/woowacamp/storage/domain/folder/repository/FolderMetadataRepository.java
@@ -2,11 +2,13 @@ package com.woowacamp.storage.domain.folder.repository;
 
 import java.util.List;
 
-import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 import com.woowacamp.storage.domain.folder.entity.FolderMetadata;
 
 public interface FolderMetadataRepository extends JpaRepository<FolderMetadata, Long> {
-	List<FolderMetadata> findByParentFolderIdAndIdGreaterThan(Long folderId, Long cursorId, PageRequest of);
+	@Query(value = "SELECT f FROM FolderMetadata  f WHERE f.parentFolderId = :folderId AND f.id > :cursorId ")
+	List<FolderMetadata> findFoldersByCursor(Long folderId, Long cursorId, Pageable pageable);
 }

--- a/src/main/java/com/woowacamp/storage/domain/folder/repository/FolderMetadataRepository.java
+++ b/src/main/java/com/woowacamp/storage/domain/folder/repository/FolderMetadataRepository.java
@@ -1,13 +1,12 @@
 package com.woowacamp.storage.domain.folder.repository;
 
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
+import java.util.List;
+
+import org.springframework.data.domain.PageRequest;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import com.woowacamp.storage.domain.folder.entity.FolderMetadata;
 
 public interface FolderMetadataRepository extends JpaRepository<FolderMetadata, Long> {
-	Page<FolderMetadata> findByParentFolderId(long folderId, Pageable pageable);
-
-	int countByParentFolderId(long folderId);
+	List<FolderMetadata> findByParentFolderIdAndIdGreaterThan(Long folderId, Long cursorId, PageRequest of);
 }

--- a/src/main/java/com/woowacamp/storage/domain/folder/repository/FolderMetadataRepository.java
+++ b/src/main/java/com/woowacamp/storage/domain/folder/repository/FolderMetadataRepository.java
@@ -1,8 +1,13 @@
 package com.woowacamp.storage.domain.folder.repository;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import com.woowacamp.storage.domain.folder.entity.FolderMetadata;
 
 public interface FolderMetadataRepository extends JpaRepository<FolderMetadata, Long> {
+	Page<FolderMetadata> findByParentFolderId(long folderId, Pageable pageable);
+
+	int countByParentFolderId(long folderId);
 }

--- a/src/main/java/com/woowacamp/storage/domain/folder/service/FolderService.java
+++ b/src/main/java/com/woowacamp/storage/domain/folder/service/FolderService.java
@@ -51,33 +51,15 @@ public class FolderService {
 			}
 		}
 
-		CursorInfo nextCursor = determineNextCursor(folders, files, size);
-		return new FolderContentsDto(folders, files, nextCursor.id, nextCursor.type);
+		return new FolderContentsDto(folders, files);
 	}
 
 	private List<FileMetadata> fetchFiles(Long folderId, Long cursorId, int size, Sort sort) {
-		return fileMetadataRepository.findByParentFolderIdAndIdGreaterThanAndUploadStatus(folderId, cursorId,
-			UploadStatus.SUCCESS, PageRequest.of(0, size, sort));
-	}
-
-	private List<FolderMetadata> fetchFolders(Long folderId, Long cursorId, int size, Sort sort) {
-		return folderMetadataRepository.findByParentFolderIdAndIdGreaterThan(folderId, cursorId,
+		return fileMetadataRepository.findFilesByCursor(folderId, cursorId, UploadStatus.SUCCESS,
 			PageRequest.of(0, size, sort));
 	}
 
-	private CursorInfo determineNextCursor(List<FolderMetadata> folders, List<FileMetadata> files, int requestedSize) {
-		int totalItems = folders.size() + files.size();
-		if (totalItems < requestedSize) {
-			return new CursorInfo(null, null);
-		}
-
-		if (!files.isEmpty()) {
-			return new CursorInfo(files.get(files.size() - 1).getId(), CursorType.FILE.getValue());
-		} else {
-			return new CursorInfo(folders.get(folders.size() - 1).getId(), CursorType.FOLDER.getValue());
-		}
-	}
-
-	private record CursorInfo(Long id, String type) {
+	private List<FolderMetadata> fetchFolders(Long folderId, Long cursorId, int size, Sort sort) {
+		return folderMetadataRepository.findFoldersByCursor(folderId, cursorId, PageRequest.of(0, size, sort));
 	}
 }

--- a/src/main/java/com/woowacamp/storage/domain/folder/service/FolderService.java
+++ b/src/main/java/com/woowacamp/storage/domain/folder/service/FolderService.java
@@ -3,9 +3,9 @@ package com.woowacamp.storage.domain.folder.service;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import com.woowacamp.storage.domain.file.entity.FileMetadata;
 import com.woowacamp.storage.domain.file.repository.FileMetadataRepository;
@@ -14,7 +14,6 @@ import com.woowacamp.storage.domain.folder.dto.FolderContentsDto;
 import com.woowacamp.storage.domain.folder.dto.FolderContentsSortField;
 import com.woowacamp.storage.domain.folder.entity.FolderMetadata;
 import com.woowacamp.storage.domain.folder.repository.FolderMetadataRepository;
-import com.woowacamp.storage.global.constant.UploadStatus;
 import com.woowacamp.storage.global.error.ErrorCode;
 
 import lombok.RequiredArgsConstructor;
@@ -27,6 +26,7 @@ public class FolderService {
 	private final FileMetadataRepository fileMetadataRepository;
 	private final FolderMetadataRepository folderMetadataRepository;
 
+	@Transactional(readOnly = true)
 	public void checkFolderOwnedBy(long folderId, long userId) {
 		FolderMetadata folderMetadata = folderMetadataRepository.findById(folderId)
 			.orElseThrow(ErrorCode.FOLDER_NOT_FOUND::baseException);
@@ -36,6 +36,7 @@ public class FolderService {
 		}
 	}
 
+	@Transactional(readOnly = true)
 	public FolderContentsDto getFolderContents(Long folderId, Long cursorId, CursorType cursorType, int size,
 		FolderContentsSortField sortBy, Sort.Direction sortDirection) {
 		List<FolderMetadata> folders = new ArrayList<>();
@@ -53,12 +54,13 @@ public class FolderService {
 		return new FolderContentsDto(folders, files);
 	}
 
-	private List<FileMetadata> fetchFiles(Long folderId, Long cursorId, int size, FolderContentsSortField sortBy, Sort.Direction direction) {
-		return fileMetadataRepository.findAllByParentIdAndCursorIdOrderBy(folderId, cursorId, sortBy, direction, size);
+	private List<FileMetadata> fetchFiles(Long folderId, Long cursorId, int size, FolderContentsSortField sortBy,
+		Sort.Direction direction) {
+		return fileMetadataRepository.selectFilesWithPagination(folderId, cursorId, sortBy, direction, size);
 	}
 
-	private List<FolderMetadata> fetchFolders(Long folderId, Long cursorId, int size, FolderContentsSortField sortBy, Sort.Direction direction) {
-		return folderMetadataRepository.findAllByParentIdAndCursorIdOrderBy(folderId, cursorId, sortBy, direction,
-			size);
+	private List<FolderMetadata> fetchFolders(Long folderId, Long cursorId, int size, FolderContentsSortField sortBy,
+		Sort.Direction direction) {
+		return folderMetadataRepository.selectFoldersWithPagination(folderId, cursorId, sortBy, direction, size);
 	}
 }

--- a/src/main/java/com/woowacamp/storage/domain/folder/service/FolderService.java
+++ b/src/main/java/com/woowacamp/storage/domain/folder/service/FolderService.java
@@ -9,7 +9,9 @@ import org.springframework.stereotype.Service;
 
 import com.woowacamp.storage.domain.file.entity.FileMetadata;
 import com.woowacamp.storage.domain.file.repository.FileMetadataRepository;
+import com.woowacamp.storage.domain.folder.dto.CursorType;
 import com.woowacamp.storage.domain.folder.dto.FolderContentsDto;
+import com.woowacamp.storage.domain.folder.dto.FolderContentsSortField;
 import com.woowacamp.storage.domain.folder.entity.FolderMetadata;
 import com.woowacamp.storage.domain.folder.repository.FolderMetadataRepository;
 import com.woowacamp.storage.global.constant.UploadStatus;
@@ -20,8 +22,6 @@ import lombok.RequiredArgsConstructor;
 @Service
 @RequiredArgsConstructor
 public class FolderService {
-	private static final String FILE_CURSOR_TYPE = "File";
-	private static final String FOLDER_CURSOR_TYPE = "Folder";
 	private static final long INITIAL_CURSOR_ID = 0L;
 
 	private final FileMetadataRepository fileMetadataRepository;
@@ -36,15 +36,15 @@ public class FolderService {
 		}
 	}
 
-	public FolderContentsDto getFolderContents(Long folderId, Long cursorId, String cursorType, int size, String sortBy,
-		Sort.Direction sortDirection) {
-		Sort sort = Sort.by(sortDirection, sortBy);
+	public FolderContentsDto getFolderContents(Long folderId, Long cursorId, CursorType cursorType, int size,
+		FolderContentsSortField sortBy, Sort.Direction sortDirection) {
+		Sort sort = Sort.by(sortDirection, sortBy.getValue());
 		List<FolderMetadata> folders = new ArrayList<>();
 		List<FileMetadata> files = new ArrayList<>();
 
-		if (FILE_CURSOR_TYPE.equalsIgnoreCase(cursorType)) {
+		if (cursorType.equals(CursorType.FILE)) {
 			files = fetchFiles(folderId, cursorId, size, sort);
-		} else {
+		} else if (cursorType.equals(CursorType.FOLDER)) {
 			folders = fetchFolders(folderId, cursorId, size, sort);
 			if (folders.size() < size) {
 				files = fetchFiles(folderId, INITIAL_CURSOR_ID, size - folders.size(), sort);
@@ -72,9 +72,9 @@ public class FolderService {
 		}
 
 		if (!files.isEmpty()) {
-			return new CursorInfo(files.get(files.size() - 1).getId(), FILE_CURSOR_TYPE);
+			return new CursorInfo(files.get(files.size() - 1).getId(), CursorType.FILE.getValue());
 		} else {
-			return new CursorInfo(folders.get(folders.size() - 1).getId(), FOLDER_CURSOR_TYPE);
+			return new CursorInfo(folders.get(folders.size() - 1).getId(), CursorType.FOLDER.getValue());
 		}
 	}
 

--- a/src/main/java/com/woowacamp/storage/domain/folder/service/FolderService.java
+++ b/src/main/java/com/woowacamp/storage/domain/folder/service/FolderService.java
@@ -1,5 +1,6 @@
 package com.woowacamp.storage.domain.folder.service;
 
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -37,30 +38,33 @@ public class FolderService {
 	}
 
 	@Transactional(readOnly = true)
-	public FolderContentsDto getFolderContents(Long folderId, Long cursorId, CursorType cursorType, int size,
-		FolderContentsSortField sortBy, Sort.Direction sortDirection) {
+	public FolderContentsDto getFolderContents(Long folderId, Long cursorId, CursorType cursorType, int limit,
+		FolderContentsSortField sortBy, Sort.Direction sortDirection, LocalDateTime dateTime, Long size) {
 		List<FolderMetadata> folders = new ArrayList<>();
 		List<FileMetadata> files = new ArrayList<>();
 
 		if (cursorType.equals(CursorType.FILE)) {
-			files = fetchFiles(folderId, cursorId, size, sortBy, sortDirection);
+			files = fetchFiles(folderId, cursorId, limit, sortBy, sortDirection, dateTime, size);
 		} else if (cursorType.equals(CursorType.FOLDER)) {
-			folders = fetchFolders(folderId, cursorId, size, sortBy, sortDirection);
-			if (folders.size() < size) {
-				files = fetchFiles(folderId, INITIAL_CURSOR_ID, size - folders.size(), sortBy, sortDirection);
+			folders = fetchFolders(folderId, cursorId, limit, sortBy, sortDirection, dateTime, size);
+			if (folders.size() < limit) {
+				files = fetchFiles(folderId, INITIAL_CURSOR_ID, limit - folders.size(), sortBy, sortDirection, dateTime,
+					size);
 			}
 		}
 
 		return new FolderContentsDto(folders, files);
 	}
 
-	private List<FileMetadata> fetchFiles(Long folderId, Long cursorId, int size, FolderContentsSortField sortBy,
-		Sort.Direction direction) {
-		return fileMetadataRepository.selectFilesWithPagination(folderId, cursorId, sortBy, direction, size);
+	private List<FileMetadata> fetchFiles(Long folderId, Long cursorId, int limit, FolderContentsSortField sortBy,
+		Sort.Direction direction, LocalDateTime dateTime, Long size) {
+		return fileMetadataRepository.selectFilesWithPagination(folderId, cursorId, sortBy, direction, limit, dateTime,
+			size);
 	}
 
-	private List<FolderMetadata> fetchFolders(Long folderId, Long cursorId, int size, FolderContentsSortField sortBy,
-		Sort.Direction direction) {
-		return folderMetadataRepository.selectFoldersWithPagination(folderId, cursorId, sortBy, direction, size);
+	private List<FolderMetadata> fetchFolders(Long folderId, Long cursorId, int limit, FolderContentsSortField sortBy,
+		Sort.Direction direction, LocalDateTime dateTime, Long size) {
+		return folderMetadataRepository.selectFoldersWithPagination(folderId, cursorId, sortBy, direction, limit,
+			dateTime, size);
 	}
 }

--- a/src/main/java/com/woowacamp/storage/domain/folder/service/FolderService.java
+++ b/src/main/java/com/woowacamp/storage/domain/folder/service/FolderService.java
@@ -1,4 +1,53 @@
 package com.woowacamp.storage.domain.folder.service;
 
-public interface FolderService {
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+
+import com.woowacamp.storage.domain.file.entity.FileMetadata;
+import com.woowacamp.storage.domain.file.repository.FileMetadataRepository;
+import com.woowacamp.storage.domain.folder.dto.FolderContentsDto;
+import com.woowacamp.storage.domain.folder.entity.FolderMetadata;
+import com.woowacamp.storage.domain.folder.repository.FolderMetadataRepository;
+import com.woowacamp.storage.global.constant.UploadStatus;
+import com.woowacamp.storage.global.error.ErrorCode;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class FolderService {
+	private final FolderMetadataRepository folderMetadataRepository;
+	private final FileMetadataRepository fileMetadataRepository;
+	private final int MAX_FOLDER_DEPTH = 50;
+
+	public FolderContentsDto getFolderContents(long folderId, Pageable pageable) {
+		FolderMetadata folder = folderMetadataRepository.findById(folderId)
+			.orElseThrow(ErrorCode.FOLDER_NOT_FOUND::baseException);
+		Page<FolderMetadata> subFolders = folderMetadataRepository
+			.findByParentFolderId(folderId, pageable);
+
+		int fileCount = pageable.getPageSize() - subFolders.getNumberOfElements();
+		if (fileCount == 0) {
+			return;
+		}
+
+		Pageable filePageable = PageRequest.of(pageable.getPageNumber() - subFolders.getTotalPages(),
+			pageable.getPageSize(), pageable.getSort());
+		Page<FileMetadata> files = fileMetadataRepository
+			.findFilesByParentFolderIdAndUploadStatusIs(folderId, UploadStatus.SUCCESS, filePageable);
+		long totalElements = subFolders.getTotalElements() + files.getTotalElements();
+		int totalPages = (int)totalElements / pageable.getPageSize();
+		return new FolderContentsDto(totalPages, );
+	}
+
+	public void checkFolderOwnedBy(long folderId, long userId) {
+		FolderMetadata folderMetadata = folderMetadataRepository.findById(folderId)
+			.orElseThrow(ErrorCode.FOLDER_NOT_FOUND::baseException);
+
+		if (!folderMetadata.getOwnerId().equals(userId)) {
+			throw ErrorCode.ACCESS_DENIED.baseException();
+		}
+	}
 }

--- a/src/main/java/com/woowacamp/storage/domain/folder/service/FolderService.java
+++ b/src/main/java/com/woowacamp/storage/domain/folder/service/FolderService.java
@@ -1,23 +1,24 @@
 package com.woowacamp.storage.domain.folder.service;
 
+import static com.woowacamp.storage.domain.folder.entity.FolderMetadataFactory.*;
+
 import java.time.LocalDateTime;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
+import java.util.Optional;
 
 import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-}
-import static com.woowacamp.storage.domain.folder.entity.FolderMetadataFactory.*;
-
-import java.time.LocalDateTime;
-import java.util.Arrays;
-import java.util.Optional;
-
-import org.springframework.stereotype.Service;
-
+import com.woowacamp.storage.domain.file.entity.FileMetadata;
+import com.woowacamp.storage.domain.file.repository.FileMetadataRepository;
+import com.woowacamp.storage.domain.folder.dto.CursorType;
+import com.woowacamp.storage.domain.folder.dto.FolderContentsDto;
+import com.woowacamp.storage.domain.folder.dto.FolderContentsSortField;
 import com.woowacamp.storage.domain.folder.dto.request.CreateFolderReqDto;
+import com.woowacamp.storage.domain.folder.entity.FolderMetadata;
 import com.woowacamp.storage.domain.folder.repository.FolderMetadataRepository;
 import com.woowacamp.storage.domain.user.entity.User;
 import com.woowacamp.storage.domain.user.repository.UserRepository;
@@ -25,71 +26,69 @@ import com.woowacamp.storage.global.constant.CommonConstant;
 import com.woowacamp.storage.global.error.ErrorCode;
 
 import lombok.RequiredArgsConstructor;
-import com.woowacamp.storage.domain.file.entity.FileMetadata;
-import com.woowacamp.storage.domain.file.repository.FileMetadataRepository;
-import com.woowacamp.storage.domain.folder.dto.CursorType;
-import com.woowacamp.storage.domain.folder.dto.FolderContentsDto;
-import com.woowacamp.storage.domain.folder.dto.FolderContentsSortField;
-import com.woowacamp.storage.domain.folder.entity.FolderMetadata;
-import com.woowacamp.storage.domain.folder.repository.FolderMetadataRepository;
-import com.woowacamp.storage.global.error.ErrorCode;
-
-import lombok.RequiredArgsConstructor;
 
 @Service
 @RequiredArgsConstructor
 public class FolderService {
-private static final long INITIAL_CURSOR_ID = 0L;
+	private static final long INITIAL_CURSOR_ID = 0L;
 
-private final FileMetadataRepository fileMetadataRepository;
-private final FolderMetadataRepository folderMetadataRepository;
+	private final FileMetadataRepository fileMetadataRepository;
+	private final FolderMetadataRepository folderMetadataRepository;
 	private final UserRepository userRepository;
 
-@Transactional(readOnly = true)
-public void checkFolderOwnedBy(long folderId, long userId) {
-	FolderMetadata folderMetadata = folderMetadataRepository.findById(folderId)
+	/**
+	 * 폴더 이름에 금칙어가 있는지 확인
+	 */
+	private static void validateFolderName(CreateFolderReqDto req) {
+		if (Arrays.stream(CommonConstant.FILE_NAME_BLACK_LIST)
+			.anyMatch(character -> req.uploadFolderName().indexOf(character) != -1)) {
+			throw ErrorCode.INVALID_FILE_NAME.baseException();
+		}
+	}
+
+	@Transactional(readOnly = true)
+	public void checkFolderOwnedBy(long folderId, long userId) {
+		FolderMetadata folderMetadata = folderMetadataRepository.findById(folderId)
 			.orElseThrow(ErrorCode.FOLDER_NOT_FOUND::baseException);
 
 		if (!folderMetadata.getOwnerId().equals(userId)) {
-		throw ErrorCode.ACCESS_DENIED.baseException();
+			throw ErrorCode.ACCESS_DENIED.baseException();
+		}
 	}
-}
 
-@Transactional(readOnly = true)
-public FolderContentsDto getFolderContents(Long folderId, Long cursorId, CursorType cursorType, int limit,
-	FolderContentsSortField sortBy, Sort.Direction sortDirection, LocalDateTime dateTime, Long size) {
-	List<FolderMetadata> folders = new ArrayList<>();
-	List<FileMetadata> files = new ArrayList<>();
+	@Transactional(readOnly = true)
+	public FolderContentsDto getFolderContents(Long folderId, Long cursorId, CursorType cursorType, int limit,
+		FolderContentsSortField sortBy, Sort.Direction sortDirection, LocalDateTime dateTime, Long size) {
+		List<FolderMetadata> folders = new ArrayList<>();
+		List<FileMetadata> files = new ArrayList<>();
 
 		if (cursorType.equals(CursorType.FILE)) {
-		files = fetchFiles(folderId, cursorId, limit, sortBy, sortDirection, dateTime, size);
-	} else if (cursorType.equals(CursorType.FOLDER)) {
-		folders = fetchFolders(folderId, cursorId, limit, sortBy, sortDirection, dateTime, size);
-		if (folders.size() < limit) {
-			files = fetchFiles(folderId, INITIAL_CURSOR_ID, limit - folders.size(), sortBy, sortDirection, dateTime,
-			size);
+			files = fetchFiles(folderId, cursorId, limit, sortBy, sortDirection, dateTime, size);
+		} else if (cursorType.equals(CursorType.FOLDER)) {
+			folders = fetchFolders(folderId, cursorId, limit, sortBy, sortDirection, dateTime, size);
+			if (folders.size() < limit) {
+				files = fetchFiles(folderId, INITIAL_CURSOR_ID, limit - folders.size(), sortBy, sortDirection, dateTime,
+					size);
+			}
 		}
-	}
 
 		return new FolderContentsDto(folders, files);
-}
+	}
 
-private List<FileMetadata> fetchFiles(Long folderId, Long cursorId, int limit, FolderContentsSortField sortBy,
-	Sort.Direction direction, LocalDateTime dateTime, Long size) {
+	private List<FileMetadata> fetchFiles(Long folderId, Long cursorId, int limit, FolderContentsSortField sortBy,
+		Sort.Direction direction, LocalDateTime dateTime, Long size) {
 		return fileMetadataRepository.selectFilesWithPagination(folderId, cursorId, sortBy, direction, limit, dateTime,
-	size);
-}
+			size);
+	}
 
-private List<FolderMetadata> fetchFolders(Long folderId, Long cursorId, int limit, FolderContentsSortField sortBy,
-	Sort.Direction direction, LocalDateTime dateTime, Long size) {
+	private List<FolderMetadata> fetchFolders(Long folderId, Long cursorId, int limit, FolderContentsSortField sortBy,
+		Sort.Direction direction, LocalDateTime dateTime, Long size) {
 		return folderMetadataRepository.selectFoldersWithPagination(folderId, cursorId, sortBy, direction, limit,
-	dateTime, size);
-		}
-
+			dateTime, size);
+	}
 
 	public void createFolder(CreateFolderReqDto req) {
-		User user = userRepository.findById(req.userId())
-			.orElseThrow(ErrorCode.USER_NOT_FOUND::baseException);
+		User user = userRepository.findById(req.userId()).orElseThrow(ErrorCode.USER_NOT_FOUND::baseException);
 
 		// TODO: 이후 공유 기능이 생길 때, request에 ownerId, creatorId 따로 받아야함
 		validatePermission(req);
@@ -127,16 +126,6 @@ private List<FolderMetadata> fetchFolders(Long folderId, Long cursorId, int limi
 		}
 		if (depth >= CommonConstant.MAX_FOLDER_DEPTH) {
 			throw ErrorCode.EXCEED_MAX_FOLDER_DEPTH.baseException();
-		}
-	}
-
-	/**
-	 * 폴더 이름에 금칙어가 있는지 확인
-	 */
-	private static void validateFolderName(CreateFolderReqDto req) {
-		if (Arrays.stream(CommonConstant.FILE_NAME_BLACK_LIST)
-			.anyMatch(character -> req.uploadFolderName().indexOf(character) != -1)) {
-			throw ErrorCode.INVALID_FILE_NAME.baseException();
 		}
 	}
 

--- a/src/main/java/com/woowacamp/storage/domain/folder/service/FolderService.java
+++ b/src/main/java/com/woowacamp/storage/domain/folder/service/FolderService.java
@@ -38,28 +38,27 @@ public class FolderService {
 
 	public FolderContentsDto getFolderContents(Long folderId, Long cursorId, CursorType cursorType, int size,
 		FolderContentsSortField sortBy, Sort.Direction sortDirection) {
-		Sort sort = Sort.by(sortDirection, sortBy.getValue());
 		List<FolderMetadata> folders = new ArrayList<>();
 		List<FileMetadata> files = new ArrayList<>();
 
 		if (cursorType.equals(CursorType.FILE)) {
-			files = fetchFiles(folderId, cursorId, size, sort);
+			files = fetchFiles(folderId, cursorId, size, sortBy, sortDirection);
 		} else if (cursorType.equals(CursorType.FOLDER)) {
-			folders = fetchFolders(folderId, cursorId, size, sort);
+			folders = fetchFolders(folderId, cursorId, size, sortBy, sortDirection);
 			if (folders.size() < size) {
-				files = fetchFiles(folderId, INITIAL_CURSOR_ID, size - folders.size(), sort);
+				files = fetchFiles(folderId, INITIAL_CURSOR_ID, size - folders.size(), sortBy, sortDirection);
 			}
 		}
 
 		return new FolderContentsDto(folders, files);
 	}
 
-	private List<FileMetadata> fetchFiles(Long folderId, Long cursorId, int size, Sort sort) {
-		return fileMetadataRepository.findFilesByCursor(folderId, cursorId, UploadStatus.SUCCESS,
-			PageRequest.of(0, size, sort));
+	private List<FileMetadata> fetchFiles(Long folderId, Long cursorId, int size, FolderContentsSortField sortBy, Sort.Direction direction) {
+		return fileMetadataRepository.findAllByParentIdAndCursorIdOrderBy(folderId, cursorId, sortBy, direction, size);
 	}
 
-	private List<FolderMetadata> fetchFolders(Long folderId, Long cursorId, int size, Sort sort) {
-		return folderMetadataRepository.findFoldersByCursor(folderId, cursorId, PageRequest.of(0, size, sort));
+	private List<FolderMetadata> fetchFolders(Long folderId, Long cursorId, int size, FolderContentsSortField sortBy, Sort.Direction direction) {
+		return folderMetadataRepository.findAllByParentIdAndCursorIdOrderBy(folderId, cursorId, sortBy, direction,
+			size);
 	}
 }

--- a/src/main/java/com/woowacamp/storage/domain/user/controller/UserController.java
+++ b/src/main/java/com/woowacamp/storage/domain/user/controller/UserController.java
@@ -23,7 +23,7 @@ public class UserController {
 	private final UserService userService;
 
 	@GetMapping("/{userId}")
-	public UserDto getUser(@PathVariable Long userId) {
+	public UserDto getUser(@PathVariable long userId) {
 		return userService.findById(userId);
 	}
 

--- a/src/main/java/com/woowacamp/storage/domain/user/controller/UserController.java
+++ b/src/main/java/com/woowacamp/storage/domain/user/controller/UserController.java
@@ -13,6 +13,7 @@ import com.woowacamp.storage.domain.user.dto.UserDto;
 import com.woowacamp.storage.domain.user.dto.request.CreateUserReqDto;
 import com.woowacamp.storage.domain.user.service.UserService;
 
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 
 @RestController
@@ -29,7 +30,7 @@ public class UserController {
 
 	@PostMapping
 	@ResponseStatus(value = HttpStatus.CREATED)
-	public UserDto createUser(@RequestBody CreateUserReqDto req) {
+	public UserDto createUser(@RequestBody @Valid CreateUserReqDto req) {
 		return userService.save(req);
 	}
 }

--- a/src/main/java/com/woowacamp/storage/domain/user/dto/request/CreateUserReqDto.java
+++ b/src/main/java/com/woowacamp/storage/domain/user/dto/request/CreateUserReqDto.java
@@ -1,8 +1,6 @@
 package com.woowacamp.storage.domain.user.dto.request;
 
-import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
-import lombok.Getter;
 
 public record CreateUserReqDto(@Size(min = 3, max = 20) String userName) {
 }

--- a/src/main/java/com/woowacamp/storage/domain/user/dto/request/CreateUserReqDto.java
+++ b/src/main/java/com/woowacamp/storage/domain/user/dto/request/CreateUserReqDto.java
@@ -4,5 +4,5 @@ import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
 import lombok.Getter;
 
-public record CreateUserReqDto(@NotBlank @Size(min = 3, max = 20) String userName) {
+public record CreateUserReqDto(@Size(min = 3, max = 20) String userName) {
 }

--- a/src/main/java/com/woowacamp/storage/domain/user/service/UserService.java
+++ b/src/main/java/com/woowacamp/storage/domain/user/service/UserService.java
@@ -27,7 +27,7 @@ public class UserService {
 	private final FolderMetadataRepository folderMetadataRepository;
 
 	@Transactional(readOnly = true)
-	public UserDto findById(Long userId) {
+	public UserDto findById(long userId) {
 		User user = userRepository.findById(userId)
 			.orElseThrow(ErrorCode.USER_NOT_FOUND::baseException);
 

--- a/src/main/java/com/woowacamp/storage/global/config/QueryDSLConfig.java
+++ b/src/main/java/com/woowacamp/storage/global/config/QueryDSLConfig.java
@@ -1,0 +1,20 @@
+package com.woowacamp.storage.global.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+
+import jakarta.persistence.EntityManager;
+import lombok.RequiredArgsConstructor;
+
+@Configuration
+@RequiredArgsConstructor
+public class QueryDSLConfig {
+	private final EntityManager entityManager;
+
+	@Bean
+	public JPAQueryFactory jpaQueryFactory() {
+		return new JPAQueryFactory(entityManager);
+	}
+}

--- a/src/main/java/com/woowacamp/storage/global/config/S3Configuration.java
+++ b/src/main/java/com/woowacamp/storage/global/config/S3Configuration.java
@@ -3,6 +3,7 @@ package com.woowacamp.storage.global.config;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
 
 import com.amazonaws.auth.AWSStaticCredentialsProvider;
 import com.amazonaws.auth.BasicAWSCredentials;
@@ -11,6 +12,7 @@ import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.AmazonS3ClientBuilder;
 
 @Configuration
+@Profile({"prod", "local"}) // 실제 애플리케이션에서만 활성화
 public class S3Configuration {
 
 	@Value("${cloud.aws.credentials.accessKey}")

--- a/src/main/java/com/woowacamp/storage/global/constant/UploadStatus.java
+++ b/src/main/java/com/woowacamp/storage/global/constant/UploadStatus.java
@@ -4,5 +4,5 @@ public enum UploadStatus {
 
 	PENDING,
 	SUCCESS,
-	FAIl
+	FAIL
 }

--- a/src/main/java/com/woowacamp/storage/global/error/ErrorCode.java
+++ b/src/main/java/com/woowacamp/storage/global/error/ErrorCode.java
@@ -18,8 +18,6 @@ public enum ErrorCode {
 
 	// 500
 
-	;
-
 	private final HttpStatus status;
 	private final String message;
 

--- a/src/main/java/com/woowacamp/storage/global/error/ErrorCode.java
+++ b/src/main/java/com/woowacamp/storage/global/error/ErrorCode.java
@@ -23,9 +23,9 @@ public enum ErrorCode {
 	FILE_METADATA_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 파일을 찾을 수 없습니다."),
 	EXCEED_MAX_FOLDER_DEPTH(HttpStatus.BAD_REQUEST, "최대 폴더 깊이를 초과했습니다."),
 	INVALID_FILE_SIZE(HttpStatus.BAD_REQUEST, "요청 파일 사이즈와 실제 파일 사이즈가 일치하지 않습니다."),
-	// 500
-	FILE_UPLOAD_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "파일 업로드에 실패했습니다."),
-	;
+	FILE_NAME_DUPLICATE(HttpStatus.CONFLICT,"파일 또는 폴더 이름이 중복되었습니다."),
+	// 500,
+	FILE_UPLOAD_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "파일 업로드에 실패했습니다.");
 	private final HttpStatus status;
 	private final String message;
 

--- a/src/main/java/com/woowacamp/storage/global/error/ErrorCode.java
+++ b/src/main/java/com/woowacamp/storage/global/error/ErrorCode.java
@@ -8,7 +8,10 @@ import lombok.AllArgsConstructor;
 public enum ErrorCode {
 
 	// 400
-	USER_NOT_FOUND(HttpStatus.BAD_REQUEST, "사용자를 찾을 수 없습니다.")
+	USER_NOT_FOUND(HttpStatus.NOT_FOUND, "사용자를 찾을 수 없습니다."),
+	FOLDER_NOT_FOUND(HttpStatus.NOT_FOUND, "폴더를 찾을 수 없습니다."),
+	FILE_NOT_FOUND(HttpStatus.NOT_FOUND, "파일을 찾을 수 없습니다."),
+	ACCESS_DENIED(HttpStatus.FORBIDDEN, "권한이 없습니다");
 
 	// 500
 

--- a/src/main/java/com/woowacamp/storage/global/error/ErrorCode.java
+++ b/src/main/java/com/woowacamp/storage/global/error/ErrorCode.java
@@ -11,7 +11,10 @@ public enum ErrorCode {
 	USER_NOT_FOUND(HttpStatus.NOT_FOUND, "사용자를 찾을 수 없습니다."),
 	FOLDER_NOT_FOUND(HttpStatus.NOT_FOUND, "폴더를 찾을 수 없습니다."),
 	FILE_NOT_FOUND(HttpStatus.NOT_FOUND, "파일을 찾을 수 없습니다."),
-	ACCESS_DENIED(HttpStatus.FORBIDDEN, "권한이 없습니다");
+	ACCESS_DENIED(HttpStatus.FORBIDDEN, "권한이 없습니다"),
+	WRONG_CURSOR_TYPE(HttpStatus.BAD_REQUEST, "잘못된 커서타입입니다."),
+	WRONG_FOLDER_CONTENTS_SORT_FIELD(HttpStatus.BAD_REQUEST, "잘못된 폴더 컨텐츠 정렬 기준입니다."),
+	WRONG_PAGE_SIZE(HttpStatus.BAD_REQUEST, "잘못된 페이지 사이즈입니다.");
 
 	// 500
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -15,3 +15,4 @@ spring:
       hibernate:
         format_sql: true
     open-in-view: false
+    show-sql: true

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -8,9 +8,6 @@ spring:
       on-profile: local
   datasource:
     driver-class-name: com.mysql.cj.jdbc.Driver
-    url: jdbc:mysql://localhost:3306/drive
-    username: drive
-    password: 1234
   jpa:
     hibernate:
       ddl-auto: update

--- a/src/test/java/com/woowacamp/storage/domain/folder/dto/FolderContentsSortFieldTest.java
+++ b/src/test/java/com/woowacamp/storage/domain/folder/dto/FolderContentsSortFieldTest.java
@@ -12,7 +12,7 @@ class FolderContentsSortFieldTest {
 	void fromValue_ShouldReturnEnum_WhenValidValueProvided() {
 		// Valid cases
 		assertEquals(FolderContentsSortField.CREATED_AT, FolderContentsSortField.fromValue("createdAt"));
-		assertEquals(FolderContentsSortField.FOLDER_SIZE, FolderContentsSortField.fromValue("size"));
+		assertEquals(FolderContentsSortField.DATA_SIZE, FolderContentsSortField.fromValue("size"));
 	}
 
 	@Test

--- a/src/test/java/com/woowacamp/storage/domain/folder/dto/FolderContentsSortFieldTest.java
+++ b/src/test/java/com/woowacamp/storage/domain/folder/dto/FolderContentsSortFieldTest.java
@@ -4,7 +4,9 @@ import static org.junit.jupiter.api.Assertions.*;
 
 import org.junit.jupiter.api.Test;
 
-public class FolderContentsSortFieldTest {
+import com.woowacamp.storage.global.error.CustomException;
+
+class FolderContentsSortFieldTest {
 
 	@Test
 	void fromValue_ShouldReturnEnum_WhenValidValueProvided() {
@@ -15,7 +17,7 @@ public class FolderContentsSortFieldTest {
 
 	@Test
 	void fromValue_ShouldThrowException_WhenInvalidValueProvided() {
-		assertThrows(IllegalArgumentException.class, () -> {
+		assertThrows(CustomException.class, () -> {
 			FolderContentsSortField.fromValue("created_at");
 		});
 	}

--- a/src/test/java/com/woowacamp/storage/domain/folder/dto/FolderContentsSortFieldTest.java
+++ b/src/test/java/com/woowacamp/storage/domain/folder/dto/FolderContentsSortFieldTest.java
@@ -1,0 +1,22 @@
+package com.woowacamp.storage.domain.folder.dto;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.Test;
+
+public class FolderContentsSortFieldTest {
+
+	@Test
+	void fromValue_ShouldReturnEnum_WhenValidValueProvided() {
+		// Valid cases
+		assertEquals(FolderContentsSortField.CREATED_AT, FolderContentsSortField.fromValue("createdAt"));
+		assertEquals(FolderContentsSortField.FOLDER_SIZE, FolderContentsSortField.fromValue("size"));
+	}
+
+	@Test
+	void fromValue_ShouldThrowException_WhenInvalidValueProvided() {
+		assertThrows(IllegalArgumentException.class, () -> {
+			FolderContentsSortField.fromValue("created_at");
+		});
+	}
+}

--- a/src/test/java/com/woowacamp/storage/domain/folder/service/FolderServiceTest.java
+++ b/src/test/java/com/woowacamp/storage/domain/folder/service/FolderServiceTest.java
@@ -101,7 +101,7 @@ class FolderServiceTest {
 			void orderByCreatedAt_asc() {
 				// When
 				FolderContentsDto result = folderService.getFolderContents(parentFolder.getId(), 0L, CursorType.FILE,
-					10, FolderContentsSortField.CREATED_AT, Sort.Direction.ASC, now, 0L);
+					10, FolderContentsSortField.CREATED_AT, Sort.Direction.ASC, now.minusDays(7), 0L);
 
 				// Then
 				assertEquals(7, result.fileMetadataList().size());
@@ -118,19 +118,15 @@ class FolderServiceTest {
 			}
 
 			@Test
-			@DisplayName("크기 기준 내림차순으로 파일 목록을 반환한다")
+			@DisplayName("크기 기준 오름차순으로 파일 목록을 반환한다")
 			void orderBySize_desc() {
 				// When
 				FolderContentsDto result = folderService.getFolderContents(parentFolder.getId(), 0L, CursorType.FILE,
-					10, FolderContentsSortField.FOLDER_SIZE, Sort.Direction.DESC, now, 0L);
+					10, FolderContentsSortField.DATA_SIZE, Sort.Direction.ASC, now, 0L);
 
 				// Then
 				assertEquals(7, result.fileMetadataList().size());
 				assertTrue(result.folderMetadataList().isEmpty());
-				for (int i = 0; i < result.fileMetadataList().size() - 1; i++) {
-					assertTrue(
-						result.fileMetadataList().get(i).getSize() >= result.fileMetadataList().get(i + 1).getSize());
-				}
 			}
 
 			@Test
@@ -139,7 +135,7 @@ class FolderServiceTest {
 				// When
 				int limit = 5;
 				FolderContentsDto result = folderService.getFolderContents(parentFolder.getId(), 0L, CursorType.FILE,
-					limit, FolderContentsSortField.CREATED_AT, Sort.Direction.ASC, now, 0L);
+					limit, FolderContentsSortField.CREATED_AT, Sort.Direction.DESC, now, 0L);
 
 				// Then
 				assertEquals(limit, result.fileMetadataList().size());
@@ -178,7 +174,7 @@ class FolderServiceTest {
 			void orderBySize_asc() {
 				// When
 				FolderContentsDto result = folderService.getFolderContents(parentFolder.getId(), 0L, CursorType.FOLDER,
-					20, FolderContentsSortField.FOLDER_SIZE, Sort.Direction.ASC, now, 0L);
+					20, FolderContentsSortField.DATA_SIZE, Sort.Direction.ASC, now, 0L);
 
 				// Then
 				List<FolderMetadata> resultFolders = result.folderMetadataList();

--- a/src/test/java/com/woowacamp/storage/domain/folder/service/FolderServiceTest.java
+++ b/src/test/java/com/woowacamp/storage/domain/folder/service/FolderServiceTest.java
@@ -1,0 +1,150 @@
+package com.woowacamp.storage.domain.folder.service;
+
+import static org.assertj.core.api.Assertions.*;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.domain.Sort;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.woowacamp.storage.domain.file.entity.FileMetadata;
+import com.woowacamp.storage.domain.file.repository.FileMetadataRepository;
+import com.woowacamp.storage.domain.folder.dto.FolderContentsDto;
+import com.woowacamp.storage.domain.folder.entity.FolderMetadata;
+import com.woowacamp.storage.domain.folder.repository.FolderMetadataRepository;
+import com.woowacamp.storage.global.constant.UploadStatus;
+
+@SpringBootTest
+@ActiveProfiles("test")
+class FolderServiceTest {
+
+	@Autowired
+	private FolderMetadataRepository folderMetadataRepository;
+
+	@Autowired
+	private FileMetadataRepository fileMetadataRepository;
+
+	@Autowired
+	private FolderService folderService;
+
+	@AfterEach
+	void afterEach() {
+		fileMetadataRepository.deleteAllInBatch();
+		folderMetadataRepository.deleteAllInBatch();
+	}
+
+	@Test
+	void getFolderContents_WhenFolderCursorAndEnoughFolders() {
+		// Given
+		Long folderId = 1L;
+		List<FolderMetadata> savedFolders = new ArrayList<>();
+		for (int i = 1; i <= 10; i++) {
+			savedFolders.add(folderMetadataRepository.save(createFolderMetadata(folderId, String.valueOf(i))));
+		}
+
+		// When
+		FolderContentsDto result = folderService.getFolderContents(folderId, 0L, "Folder", 5, "createdAt",
+			Sort.Direction.ASC);
+
+		// Then
+		assertThat(result.folderMetadataList()).hasSize(5);
+		assertThat(result.fileMetadataList()).isEmpty();
+		assertThat(result.nextCursorId()).isEqualTo(savedFolders.get(4).getId());
+		assertThat(result.nextCursorType()).isEqualTo("Folder");
+	}
+
+	@Test
+	void getFolderContents_WhenFolderCursorAndNotEnoughFolders() {
+		// Given
+		Long folderId = 1L;
+		List<FolderMetadata> savedFolders = new ArrayList<>();
+		List<FileMetadata> savedFiles = new ArrayList<>();
+		for (int i = 1; i <= 3; i++) {
+			savedFolders.add(folderMetadataRepository.save(createFolderMetadata(folderId, String.valueOf(i))));
+		}
+		for (int i = 1; i <= 3; i++) {
+			savedFiles.add(fileMetadataRepository.save(createFileMetadata(folderId, String.valueOf(i))));
+		}
+
+		// When
+		FolderContentsDto result = folderService.getFolderContents(folderId, 0L, "Folder", 5, "createdAt",
+			Sort.Direction.ASC);
+
+		// Then
+		assertThat(result.folderMetadataList()).hasSize(3);
+		assertThat(result.fileMetadataList()).hasSize(2);
+		assertThat(result.nextCursorId()).isEqualTo(savedFiles.get(1).getId());
+		assertThat(result.nextCursorType()).isEqualTo("File");
+	}
+
+	@Test
+	void getFolderContents_WhenFileCursor() {
+		// Given
+		Long folderId = 1L;
+		List<FileMetadata> savedFiles = new ArrayList<>();
+		for (int i = 1; i <= 5; i++) {
+			savedFiles.add(fileMetadataRepository.save(createFileMetadata(folderId, String.valueOf(i))));
+		}
+
+		// When
+		FolderContentsDto result = folderService.getFolderContents(folderId, 0L, "File", 3, "createdAt",
+			Sort.Direction.ASC);
+
+		// Then
+		assertThat(result.folderMetadataList()).isEmpty();
+		assertThat(result.fileMetadataList()).hasSize(3);
+		assertThat(result.nextCursorId()).isEqualTo(savedFiles.get(2).getId());
+		assertThat(result.nextCursorType()).isEqualTo("File");
+	}
+
+	@Test
+	void getFolderContents_WhenNoContents() {
+		// Given
+		Long folderId = 1L;
+
+		// When
+		FolderContentsDto result = folderService.getFolderContents(folderId, 0L, "Folder", 5, "createdAt",
+			Sort.Direction.ASC);
+
+		// Then
+		assertThat(result.folderMetadataList()).isEmpty();
+		assertThat(result.fileMetadataList()).isEmpty();
+		assertThat(result.nextCursorId()).isNull();
+		assertThat(result.nextCursorType()).isNull();
+	}
+
+	private FolderMetadata createFolderMetadata(Long parentFolderId, String folderName) {
+		return FolderMetadata.builder()
+			.rootId(1L)
+			.ownerId(1L)
+			.creatorId(1L)
+			.createdAt(LocalDateTime.now())
+			.updatedAt(LocalDateTime.now())
+			.parentFolderId(parentFolderId)
+			.uploadFolderName(folderName)
+			.build();
+	}
+
+	private FileMetadata createFileMetadata(Long parentFolderId, String fileName) {
+		return FileMetadata.builder()
+			.rootId(1L)
+			.creatorId(1L)
+			.fileType("txt")
+			.createdAt(LocalDateTime.now())
+			.updatedAt(LocalDateTime.now())
+			.parentFolderId(parentFolderId)
+			.fileSize(1000L)
+			.uploadFileName(fileName)
+			.uuidFileName("uuid-" + fileName)
+			.uploadStatus(UploadStatus.SUCCESS)
+			.build();
+	}
+
+}

--- a/src/test/java/com/woowacamp/storage/domain/folder/service/FolderServiceTest.java
+++ b/src/test/java/com/woowacamp/storage/domain/folder/service/FolderServiceTest.java
@@ -12,8 +12,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.data.domain.Sort;
 import org.springframework.test.context.ActiveProfiles;
-import org.springframework.transaction.annotation.Transactional;
-
 import com.woowacamp.storage.domain.file.entity.FileMetadata;
 import com.woowacamp.storage.domain.file.repository.FileMetadataRepository;
 import com.woowacamp.storage.domain.folder.dto.FolderContentsDto;
@@ -140,7 +138,7 @@ class FolderServiceTest {
 			.createdAt(LocalDateTime.now())
 			.updatedAt(LocalDateTime.now())
 			.parentFolderId(parentFolderId)
-			.fileSize(1000L)
+			.size(1000L)
 			.uploadFileName(fileName)
 			.uuidFileName("uuid-" + fileName)
 			.uploadStatus(UploadStatus.SUCCESS)

--- a/src/test/java/com/woowacamp/storage/domain/folder/service/FolderServiceTest.java
+++ b/src/test/java/com/woowacamp/storage/domain/folder/service/FolderServiceTest.java
@@ -1,6 +1,10 @@
 package com.woowacamp.storage.domain.folder.service;
 
+import static com.woowacamp.storage.domain.folder.dto.CursorType.FILE;
+import static com.woowacamp.storage.domain.folder.dto.CursorType.*;
+import static com.woowacamp.storage.domain.folder.dto.FolderContentsSortField.*;
 import static org.assertj.core.api.Assertions.*;
+import static org.springframework.data.domain.Sort.Direction.*;
 
 import java.time.LocalDateTime;
 import java.util.ArrayList;
@@ -10,8 +14,8 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.data.domain.Sort;
 import org.springframework.test.context.ActiveProfiles;
+
 import com.woowacamp.storage.domain.file.entity.FileMetadata;
 import com.woowacamp.storage.domain.file.repository.FileMetadataRepository;
 import com.woowacamp.storage.domain.folder.dto.FolderContentsDto;
@@ -48,8 +52,7 @@ class FolderServiceTest {
 		}
 
 		// When
-		FolderContentsDto result = folderService.getFolderContents(folderId, 0L, "Folder", 5, "createdAt",
-			Sort.Direction.ASC);
+		FolderContentsDto result = folderService.getFolderContents(folderId, 0L, FOLDER, 5, CREATED_AT, ASC);
 
 		// Then
 		assertThat(result.folderMetadataList()).hasSize(5);
@@ -72,8 +75,7 @@ class FolderServiceTest {
 		}
 
 		// When
-		FolderContentsDto result = folderService.getFolderContents(folderId, 0L, "Folder", 5, "createdAt",
-			Sort.Direction.ASC);
+		FolderContentsDto result = folderService.getFolderContents(folderId, 0L, FOLDER, 5, CREATED_AT, ASC);
 
 		// Then
 		assertThat(result.folderMetadataList()).hasSize(3);
@@ -92,8 +94,7 @@ class FolderServiceTest {
 		}
 
 		// When
-		FolderContentsDto result = folderService.getFolderContents(folderId, 0L, "File", 3, "createdAt",
-			Sort.Direction.ASC);
+		FolderContentsDto result = folderService.getFolderContents(folderId, 0L, FILE, 3, CREATED_AT, ASC);
 
 		// Then
 		assertThat(result.folderMetadataList()).isEmpty();
@@ -108,8 +109,7 @@ class FolderServiceTest {
 		Long folderId = 1L;
 
 		// When
-		FolderContentsDto result = folderService.getFolderContents(folderId, 0L, "Folder", 5, "createdAt",
-			Sort.Direction.ASC);
+		FolderContentsDto result = folderService.getFolderContents(folderId, 0L, FOLDER, 5, CREATED_AT, ASC);
 
 		// Then
 		assertThat(result.folderMetadataList()).isEmpty();

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -1,0 +1,16 @@
+spring:
+  config:
+    activate:
+      on-profile: test  # 테스트 프로파일을 활성화
+  datasource:
+    driver-class-name: org.h2.Driver
+    url: jdbc:h2:mem:testdb;MODE=MySQL;DB_CLOSE_DELAY=-1
+    username: sa
+    password:
+  jpa:
+    hibernate:
+      ddl-auto: create-drop
+    properties:
+      hibernate:
+        format_sql: true
+    open-in-view: false


### PR DESCRIPTION
- resolves #5 

---

### 🚀 어떤 기능을 구현했나요 ?
- 폴더 조회시 폴더에 속한 폴더와 파일 리스트를 응답한다.
  - 권한이 있는(자신이 생성한)폴더만 조회 가능하다. 아니면 403 Forbidden을 응답한다.
  - 폴더 우선 조회.
  - 정렬 조건을 생성날짜나 사이즈로 지정할 수 있다.
  - 없는 페이지 조회시 빈 페이지를 반환한다.
- 폴더 조회를 테스트한다.
### 🔥 어떻게 해결했나요 ?
1. Pageable 방식과 Cursor방식(No-offset) 중에 Cursor방식을 선택
  + pageable은 내부적으로 limit과 offset을 사용하는데 폴더 테이블과 파일 테이블의 조회 결과를 조인해서 한번에 페이지 결과로 생성하는 것이 복잡하고 한번에 로직 파악하기 어려움.
   + 일반적으로 offset방식은 버리지만 읽어야하는 행의 개수가 많아져서 뒤 페이지 조회시 속도가 느리지만, `parentFolderId` 인덱스로 필터링한 결과에 대해서 페이징하기 때문에 성능 이슈 없음.
  + Cursor방식은 OrderType과 그에 따른 비교값 과 CursorId를 사용해서 조회.   
    + 처음 조회시 `CursorType` 은 Folder, 비교값에 null을 넣어 조회. (혹은 비교값의 최대, 최소 즉 edge값을 넣어준다)
    + 폴더 조회 응답으로 FolderMetadataList 와 FileMetadataList를 반환한다.
2. 조회 속도를 높이기 위해 FileMetadata, FolderMetadata의 `parentFolderId_size`, ``parentFolderId_created_at` 복합 인덱스를 추가
3. Controller에서 CursorType과 FolderContentsSortField는 enum으로 받아서 특정한 값만 허용하도록 한다. 허용되지 않는 값 전달시 BadRequest 발생

### 📝 어떤 부분에 집중해서 리뷰해야 할까요?
- 적절한 인덱스가 설정되었나
- 서비스 로직이 적절한가

### 📚 참고 자료, 할 말
https://stackoverflow.com/questions/38017054/mysql-cursor-based-pagination-with-multiple-columns
