### PR TITLE
[BE] 썸네일을 추출한다.

### DIFF
--- a/src/main/java/com/woowacamp/storage/domain/file/dto/FileMetadataDto.java
+++ b/src/main/java/com/woowacamp/storage/domain/file/dto/FileMetadataDto.java
@@ -3,9 +3,10 @@ package com.woowacamp.storage.domain.file.dto;
 import com.woowacamp.storage.domain.file.entity.FileMetadata;
 
 public record FileMetadataDto(Long metadataId, String uuid, Long ownerId, Long parentFolderId, long fileSize,
-							  String uploadFileName) {
+							  String uploadFileName, String thumbnailUUID) {
 	public static FileMetadataDto of(FileMetadata fileMetadata) {
 		return new FileMetadataDto(fileMetadata.getId(), fileMetadata.getUuidFileName(), fileMetadata.getOwnerId(),
-			fileMetadata.getParentFolderId(), fileMetadata.getFileSize(), fileMetadata.getUploadFileName());
+			fileMetadata.getParentFolderId(), fileMetadata.getFileSize(), fileMetadata.getUploadFileName(),
+			fileMetadata.getThumbnailUUID());
 	}
 }

--- a/src/main/java/com/woowacamp/storage/domain/file/dto/UploadContext.java
+++ b/src/main/java/com/woowacamp/storage/domain/file/dto/UploadContext.java
@@ -1,19 +1,24 @@
 package com.woowacamp.storage.domain.file.dto;
 
+import java.io.IOException;
+import java.io.PipedInputStream;
+import java.io.PipedOutputStream;
 import java.util.Map;
 
 import lombok.Getter;
 
+@Getter
 public final class UploadContext {
-	@Getter
 	private final String boundary;
-	@Getter
 	private final String finalBoundary;
-	@Getter
 	private final Map<String, String> formFields;
 	private boolean isFileRead;
-	@Getter
 	private FileMetadataDto fileMetadata;
+	private String imageFormat;
+	private PipedOutputStream pos;
+	private PipedInputStream pis;
+	private boolean startedCreatedThumbnail;
+	private boolean abortedCreateThumbnail;
 
 	public UploadContext(
 		String boundary,
@@ -25,6 +30,11 @@ public final class UploadContext {
 		this.finalBoundary = finalBoundary;
 		this.formFields = formFields;
 		this.isFileRead = isFileRead;
+		this.imageFormat = null;
+		this.pos = null;
+		this.pis = null;
+		this.startedCreatedThumbnail = false;
+		this.abortedCreateThumbnail = false;
 	}
 
 	public boolean isFileRead() {
@@ -37,5 +47,21 @@ public final class UploadContext {
 
 	public void updateFileMetadata(FileMetadataDto fileMetadata) {
 		this.fileMetadata = fileMetadata;
+	}
+
+	public void updateImageFormat(String imageFormat) throws IOException {
+		this.imageFormat = imageFormat;
+		this.pos = new PipedOutputStream();
+		this.pis = new PipedInputStream();
+
+		pis.connect(pos);
+	}
+
+	public void updateStartedCreatedThumbnail() {
+		this.startedCreatedThumbnail = true;
+	}
+
+	public void abortCreateThumbnail() {
+		this.abortedCreateThumbnail = true;
 	}
 }

--- a/src/main/java/com/woowacamp/storage/domain/file/entity/FileMetadata.java
+++ b/src/main/java/com/woowacamp/storage/domain/file/entity/FileMetadata.java
@@ -77,6 +77,10 @@ public class FileMetadata {
 	@NotNull
 	private UploadStatus uploadStatus;
 
+	@Column(name = "thumbnail_file_name", columnDefinition = "VARCHAR(100) NOT NULL unique")
+	@NotNull
+	private String thumbnailUUID;
+
 	@Builder
 	public FileMetadata(
 		Long id,
@@ -90,7 +94,8 @@ public class FileMetadata {
 		Long fileSize,
 		String uploadFileName,
 		String uuidFileName,
-		UploadStatus uploadStatus
+		UploadStatus uploadStatus,
+		String thumbnailUUID
 	) {
 		this.id = id;
 		this.rootId = rootId;
@@ -104,6 +109,7 @@ public class FileMetadata {
 		this.uploadFileName = uploadFileName;
 		this.uuidFileName = uuidFileName;
 		this.uploadStatus = uploadStatus;
+		this.thumbnailUUID = thumbnailUUID;
 	}
 
 	public void updateCreatedAt(LocalDateTime createdAt) {

--- a/src/main/java/com/woowacamp/storage/domain/file/entity/FileMetadataFactory.java
+++ b/src/main/java/com/woowacamp/storage/domain/file/entity/FileMetadataFactory.java
@@ -8,7 +8,7 @@ import com.woowacamp.storage.global.constant.UploadStatus;
 public class FileMetadataFactory {
 
 	public static FileMetadata buildInitialMetadata(User user, long parentFolderId, long fileSize, String uuidFileName,
-		String fileName, String fileType) {
+		String fileName, String fileType, String thumbnailUUID) {
 		LocalDateTime now = LocalDateTime.now();
 		return FileMetadata.builder()
 			.rootId(user.getRootFolderId())
@@ -22,6 +22,7 @@ public class FileMetadataFactory {
 			.fileType(fileType)
 			.createdAt(now)
 			.updatedAt(now)
+			.thumbnailUUID(thumbnailUUID)
 			.build();
 	}
 }

--- a/src/main/java/com/woowacamp/storage/domain/file/repository/FileMetadataRepository.java
+++ b/src/main/java/com/woowacamp/storage/domain/file/repository/FileMetadataRepository.java
@@ -19,25 +19,25 @@ public interface FileMetadataRepository extends JpaRepository<FileMetadata, Long
 
 	boolean existsByUuidFileName(String uuidFileName);
 
-	boolean existsByParentFolderIdAndUploadFileNameAndFileType(Long parentFolderId, String uploadFileName,
-		String fileType);
+	boolean existsByParentFolderIdAndUploadFileNameAndUploadStatusNot(Long parentFolderId, String uploadFileName,
+		UploadStatus uploadStatus);
 
 	@Transactional
 	void deleteByUuidFileName(String uuidFileName);
 
 	@Lock(LockModeType.PESSIMISTIC_WRITE)
 	@Query(value = """
-			select f from FileMetadata f where f.id = :id
+			select f from FileMetadata f where f.id = :id and f.uploadStatus != 'FAIL'
 		""")
 	Optional<FileMetadata> findByIdForUpdate(@Param("id") Long id);
 
 	@Lock(LockModeType.PESSIMISTIC_WRITE)
-	Optional<FileMetadata> findByIdAndOwnerId(Long id, Long ownerId);
+	Optional<FileMetadata> findByIdAndOwnerIdAndUploadStatusNot(Long id, Long ownerId, UploadStatus uploadStatus);
 
 	// 부모 폴더에 락을 걸고 조회하는 메소드
 	@Lock(LockModeType.PESSIMISTIC_WRITE)
 	@Query(value = """
-			select f from FileMetadata f where f.parentFolderId=:parentFolderId
+			select f from FileMetadata f where f.parentFolderId=:parentFolderId and f.uploadStatus != 'FAIL'
 		""")
 	List<FileMetadata> findByParentFolderIdForUpdate(Long parentFolderId);
 
@@ -46,7 +46,7 @@ public interface FileMetadataRepository extends JpaRepository<FileMetadata, Long
 	void deleteAllByIdInBatch(@Param("ids") Iterable<Long> ids);
 
 	// 부모 폴더에 락을 걸지 않고 조회하는 메소드
-	List<FileMetadata> findByParentFolderId(Long parentFolderId);
+	List<FileMetadata> findByParentFolderIdAndUploadStatusNot(Long parentFolderId, UploadStatus uploadStatus);
 
 	@Modifying
 	@Query(value = """
@@ -72,14 +72,25 @@ public interface FileMetadataRepository extends JpaRepository<FileMetadata, Long
 		""")
 	List<FileMetadata> findOrphanFiles(@Param("orphanParentId") int orphanParentId);
 
-	@Modifying
-	@Query(value = """
-			update FileMetadata f
-			set f.uploadStatus = :uploadStatus
-			where f.id = :fileId
-		""")
-	@Transactional
-	void setMetadataStatusFail(@Param("fileId") long fileId, @Param("uploadStatus") UploadStatus uploadStatus);
-
 	boolean existsByParentFolderIdAndUploadStatus(Long parentFolderId, UploadStatus uploadStatus);
+
+	@Transactional
+	@Modifying
+	@Query("""
+			update FileMetadata f set f.uploadStatus = 'FAIL', f.updatedAt = NOW() where f.id = :fileMetadataId
+		""")
+	void updateUploadStatusById(@Param("fileMetadataId") Long fileMetadataId);
+
+	@Transactional
+	@Modifying
+	@Query("""
+			update FileMetadata f set f.uploadStatus = 'FAIL', f.updatedAt = NOW() where f.uuidFileName = :uuid
+		""")
+	void updateUploadStatusByUuid(@Param("uuid") String uuid);
+
+	@Transactional
+	@Query(value = """
+			select * from file_metadata f where f.upload_status = 'FAIL' limit 50;
+		""", nativeQuery = true)
+	List<FileMetadata> findFailedFileMetadata();
 }

--- a/src/main/java/com/woowacamp/storage/domain/file/service/FileService.java
+++ b/src/main/java/com/woowacamp/storage/domain/file/service/FileService.java
@@ -60,8 +60,8 @@ public class FileService {
 		if (fileMetadata.getUploadStatus() != UploadStatus.SUCCESS) {
 			throw ErrorCode.FILE_NOT_FOUND.baseException();
 		}
-		if (fileMetadataRepository.existsByParentFolderIdAndUploadFileNameAndFileType(dto.targetFolderId(),
-			fileMetadata.getUploadFileName(), fileMetadata.getFileType())) {
+		if (fileMetadataRepository.existsByParentFolderIdAndUploadFileNameAndUploadStatusNot(dto.targetFolderId(),
+			fileMetadata.getUploadFileName(), UploadStatus.FAIL)) {
 			throw ErrorCode.FILE_NAME_DUPLICATE.baseException();
 		}
 	}
@@ -79,7 +79,8 @@ public class FileService {
 	// private String BUCKET_NAME
 	@Transactional
 	public void deleteFile(Long fileId, Long userId) {
-		FileMetadata fileMetadata = fileMetadataRepository.findByIdAndOwnerId(fileId, userId)
+		FileMetadata fileMetadata = fileMetadataRepository.findByIdAndOwnerIdAndUploadStatusNot(fileId, userId,
+				UploadStatus.FAIL)
 			.orElseThrow(ACCESS_DENIED::baseException);
 
 		fileMetadataRepository.delete(fileMetadata);

--- a/src/main/java/com/woowacamp/storage/domain/file/service/FileWriterThreadPool.java
+++ b/src/main/java/com/woowacamp/storage/domain/file/service/FileWriterThreadPool.java
@@ -113,7 +113,7 @@ public class FileWriterThreadPool {
 			amazonS3.completeMultipartUpload(completeRequest);
 		} catch (AmazonClientException e) {
 			log.error("[Error Occurred] completeFileUpload가 정상적으로 동작하지 않습니다.");
-			fileMetadataRepository.deleteByUuidFileName(currentFileName);
+			fileMetadataRepository.updateUploadStatusByUuid(currentFileName);
 		}
 	}
 

--- a/src/main/java/com/woowacamp/storage/domain/file/service/S3FileService.java
+++ b/src/main/java/com/woowacamp/storage/domain/file/service/S3FileService.java
@@ -60,12 +60,13 @@ public class S3FileService {
 		validateRequest(formMetadataDto, partContext, user, fileName, fileType);
 
 		String uuidFileName = getUuidFileName();
+		String uuidThumbnail = "thumb_" + uuidFileName;
 
 		// 1차 메타데이터 생성
 		// TODO: 공유 기능이 생길 때, creatorId, ownerId 따로
 		FileMetadata fileMetadata = fileMetadataRepository.save(
 			FileMetadataFactory.buildInitialMetadata(user, formMetadataDto.getParentFolderId(),
-				formMetadataDto.getFileSize(), uuidFileName, fileName, fileType));
+				formMetadataDto.getFileSize(), uuidFileName, fileName, fileType, uuidThumbnail));
 
 		return FileMetadataDto.of(fileMetadata);
 	}
@@ -181,8 +182,8 @@ public class S3FileService {
 			throw ErrorCode.INVALID_FILE_NAME.baseException();
 		}
 		// 이미 해당 폴더에 같은 이름의 파일이 존재하는지 확인
-		if (fileMetadataRepository.existsByParentFolderIdAndUploadFileNameAndFileType(parentFolderId, fileName,
-			fileType)) {
+		if (fileMetadataRepository.existsByParentFolderIdAndUploadFileNameAndUploadStatusNot(parentFolderId, fileName,
+			UploadStatus.FAIL)) {
 			throw ErrorCode.FILE_NAME_DUPLICATE.baseException();
 		}
 	}

--- a/src/main/java/com/woowacamp/storage/domain/file/service/ThumbnailWriterThreadPool.java
+++ b/src/main/java/com/woowacamp/storage/domain/file/service/ThumbnailWriterThreadPool.java
@@ -1,0 +1,109 @@
+package com.woowacamp.storage.domain.file.service;
+
+import static com.woowacamp.storage.global.constant.CommonConstant.*;
+import static java.awt.image.BufferedImage.*;
+
+import java.awt.*;
+import java.awt.image.BufferedImage;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.util.Iterator;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.SynchronousQueue;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+
+import javax.imageio.ImageIO;
+import javax.imageio.ImageReadParam;
+import javax.imageio.ImageReader;
+import javax.imageio.stream.ImageInputStream;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.model.ObjectMetadata;
+import com.woowacamp.storage.domain.file.dto.UploadContext;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Service
+@Slf4j
+public class ThumbnailWriterThreadPool {
+
+	private final AmazonS3 amazonS3;
+	private final ExecutorService executorService;
+
+	@Value("${cloud.aws.credentials.bucketName}")
+	private String BUCKET_NAME;
+
+	public ThumbnailWriterThreadPool(AmazonS3 amazonS3) {
+		this.amazonS3 = amazonS3;
+		executorService = new ThreadPoolExecutor(
+			THUMBNAIL_WRITER_CORE_POOL_SIZE,
+			THUMBNAIL_WRITER_MAXIMUM_POOL_SIZE, // TODO: 톰캣 커넥션 풀 스레드 개수랑 맞춰야함
+			THUMBNAIL_WRITER_KEEP_ALIVE_TIME,
+			TimeUnit.SECONDS,
+			new SynchronousQueue<>()
+		);
+	}
+
+	public void createThumbnail(UploadContext context) {
+		executorService.execute(() -> {
+			ImageReader reader = null;
+			try (ImageInputStream iis = ImageIO.createImageInputStream(context.getPis());
+				 ByteArrayOutputStream baos = new ByteArrayOutputStream()) {
+				Iterator<ImageReader> iter = ImageIO.getImageReaders(iis);
+				if (!iter.hasNext()) {
+					throw new RuntimeException("No image readers found");
+				}
+				reader = iter.next();
+				reader.setInput(iis, true, true);
+
+				// 썸네일은 1MB 고정
+				int width = reader.getWidth(0);
+				int height = reader.getHeight(0);
+				double rate = (double)width / height;
+
+				int thumbnailSize = THUMBNAIL_SIZE / 3;
+				int thumbnailHeight = (int)Math.sqrt(thumbnailSize / rate);
+				int thumbnailWidth = (int)(thumbnailHeight * rate);
+
+				// 썸네일 비율 계산
+				double scale = (double)thumbnailWidth / width;
+				// ImageReadParam 설정
+				ImageReadParam param = reader.getDefaultReadParam();
+				param.setSourceSubsampling((int)(1 / scale), (int)(1 / scale), 0, 0);
+				// 썸네일 이미지 읽기
+				BufferedImage thumbnailImage = reader.read(0, param);
+				// 정확한 크기로 조정
+				BufferedImage finalThumbnail = new BufferedImage(thumbnailWidth, thumbnailHeight, TYPE_INT_RGB);
+				Graphics2D g2d = finalThumbnail.createGraphics();
+				g2d.drawImage(thumbnailImage, 0, 0, thumbnailWidth, thumbnailHeight, null);
+				g2d.dispose();
+
+				// finalThumbnail에 imageFormat 형태로 write
+				ImageIO.write(finalThumbnail, context.getImageFormat(), baos);
+				ObjectMetadata metadata = new ObjectMetadata();
+				metadata.setContentType("image/" + context.getImageFormat());
+				byte[] byteArray = baos.toByteArray();
+				metadata.setContentLength(byteArray.length);
+				amazonS3.putObject(BUCKET_NAME, context.getFileMetadata().thumbnailUUID(),
+					new ByteArrayInputStream(byteArray), metadata);
+			} catch (RuntimeException | IOException e) {
+				context.abortCreateThumbnail();
+				try {
+					context.getPis().close();
+					context.getPos().close();
+				} catch (IOException ex) {
+					throw new RuntimeException(ex);
+				}
+			} finally {
+				if (reader != null) {
+					reader.dispose();
+				}
+			}
+		});
+	}
+}

--- a/src/main/java/com/woowacamp/storage/domain/folder/service/FolderService.java
+++ b/src/main/java/com/woowacamp/storage/domain/folder/service/FolderService.java
@@ -294,8 +294,8 @@ public class FolderService {
 			folderIdListForDelete.add(currentFolderId);
 
 			// 하위의 파일 조회
-			List<FileMetadata> childFileMetadata = fileMetadataRepository.findByParentFolderId(
-				currentFolderId);
+			List<FileMetadata> childFileMetadata = fileMetadataRepository.findByParentFolderIdAndUploadStatusNot(
+				currentFolderId, UploadStatus.FAIL);
 
 			// 하위 파일의 실제 데이터 삭제 및 삭제해야 할 파일 id 값 저장
 			childFileMetadata.forEach(fileMetadata -> {

--- a/src/main/java/com/woowacamp/storage/global/constant/CommonConstant.java
+++ b/src/main/java/com/woowacamp/storage/global/constant/CommonConstant.java
@@ -7,5 +7,10 @@ public class CommonConstant {
 	public static final int FILE_WRITER_MAXIMUM_POOL_SIZE = 40;
 	public static final int FILE_WRITER_KEEP_ALIVE_TIME = 10;
 	public static final int FILE_WRITER_QUEUE_SIZE = 400;
+	public static final int THUMBNAIL_WRITER_CORE_POOL_SIZE = 10;
+	public static final int THUMBNAIL_WRITER_MAXIMUM_POOL_SIZE = 100;
+	public static final int THUMBNAIL_WRITER_KEEP_ALIVE_TIME = 0;
 	public static final int ORPHAN_PARENT_ID = -1;
+	// 1MB
+	public static final int THUMBNAIL_SIZE = 1024 * 1024;
 }

--- a/src/main/java/com/woowacamp/storage/global/scheduler/AbortedUploadDeleteScheduler.java
+++ b/src/main/java/com/woowacamp/storage/global/scheduler/AbortedUploadDeleteScheduler.java
@@ -56,6 +56,7 @@ public class AbortedUploadDeleteScheduler {
 				abortedUpload -> {
 					amazonS3.abortMultipartUpload(new AbortMultipartUploadRequest(BUCKET_NAME, abortedUpload.getKey(),
 						abortedUpload.getUploadId()));
+					amazonS3.deleteObject(BUCKET_NAME, "thumb_" + abortedUpload.getKey());
 					fileMetadataRepository.deleteByUuidFileName(abortedUpload.getKey());
 				});
 	}

--- a/src/main/java/com/woowacamp/storage/global/scheduler/FailFileDeleteScheduler.java
+++ b/src/main/java/com/woowacamp/storage/global/scheduler/FailFileDeleteScheduler.java
@@ -1,0 +1,57 @@
+package com.woowacamp.storage.global.scheduler;
+
+import java.util.List;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.model.AmazonS3Exception;
+import com.woowacamp.storage.domain.file.entity.FileMetadata;
+import com.woowacamp.storage.domain.file.repository.FileMetadataRepository;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * FAIL 인 파일의 썸네일과 실제 파일데이터를 S3에서 삭제하는 스케쥴러
+ */
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class FailFileDeleteScheduler {
+	public static final int DELAY = 1000 * 30;
+	private final AmazonS3 amazonS3;
+	private final FileMetadataRepository fileMetadataRepository;
+	@Value("${cloud.aws.credentials.bucketName}")
+	private String BUCKET_NAME;
+
+	/**
+	 * 업로드에 실패하여 상태가 FAIL 인 파일의 실제 데이터와 썸네일 데이터를 삭제하는 로직입니다.
+	 */
+	@Scheduled(fixedDelay = DELAY)
+	public void deleteFailFiles() {
+		List<FileMetadata> failFiles = fileMetadataRepository.findFailedFileMetadata();
+		if (failFiles.isEmpty()) {
+			return;
+		}
+
+		failFiles.forEach(fileMetadata -> {
+			try {
+				// s3 에서 파일 데이터와 썸네일 데이터를 삭제합니다.
+				String thumbnailUUID = fileMetadata.getThumbnailUUID();
+				String uuidFileName = fileMetadata.getUuidFileName();
+				amazonS3.deleteObject(BUCKET_NAME, uuidFileName);
+				if (thumbnailUUID != null) {
+					amazonS3.deleteObject(BUCKET_NAME, thumbnailUUID);
+				}
+				// 삭제가 된 경우 db 에서 메타데이터를 삭제합니다.
+				fileMetadataRepository.deleteById(fileMetadata.getId());
+			} catch (AmazonS3Exception e) {
+				log.error("[Amazon S3 Exception] cannot find fail file in S3, file metadata id = {}",
+					fileMetadata.getId());
+			}
+		});
+	}
+}

--- a/src/main/java/com/woowacamp/storage/global/scheduler/OrphanFileDeleteScheduler.java
+++ b/src/main/java/com/woowacamp/storage/global/scheduler/OrphanFileDeleteScheduler.java
@@ -53,6 +53,9 @@ public class OrphanFileDeleteScheduler {
 					fileMetadata.getUuidFileName());
 				if (Objects.nonNull(objectMetadata)) {
 					amazonS3.deleteObject(BUCKET_NAME, fileMetadata.getUploadFileName());
+					if (fileMetadata.getThumbnailUUID() != null) {
+						amazonS3.deleteObject(BUCKET_NAME, fileMetadata.getThumbnailUUID());
+					}
 					fileMetadataRepository.deleteById(fileMetadata.getId());
 				}
 			} catch (AmazonS3Exception e) {


### PR DESCRIPTION
- resolves #18

---

### 🚀 어떤 기능을 구현했나요 ?

- 썸네일을 추출한다.
- 폴더 조회 시 썸네일 관련 데이터를 응답한다.

### 🔥 어떻게 해결했나요 ?

- 썸네일 추출해야하는 파일
    - file의 content-type이 `image/`로 시작하는 파일만 썸네일을 추출합니다.
- 파일 업로드 시에 동일한 InputStream을 효율적으로 사용하기 위해 PipedStream을 사용해서 기존 InputStream과 다른 새로운 스트림으로 분기합니다.
    
    ```java
    		this.pos = new PipedOutputStream();
    		this.pis = new PipedInputStream();
    
    		pis.connect(pos);
    
    		...
    
    		context.getPos().write(lineBuffer.toByteArray());
    ```
    
- 분기된 스트림이 썸네일 생성 스레드 풀에 전달됩니다.
    - 스레드 풀의 스레드와 작업 큐는 다음과 같이 정합니다.
        - MAX_POOL_SIZE는 톰캣 커넥션 풀 스레드 개수와 동일하게 설정합니다.
            - MAX_POOL_SIZE가 톰캣 커넥션 풀 스레드 개수보다 작다면 썸네일을 생성하는 작업이 blocking 돼서 PipedOutputStream이 오버플로우 될 수도 있습니다.
        - 어짜피 파일 업로드와 썸네일 생성은 1:1로 동작하기 때문에 SynchronousQueue로 큐에 작업이 전달되자마자 스레드가 작업을 받아서 처리하도록 했습니다.
    - 썸네일은 1MB 고정 크기로 생성됩니다.
        - 하지만, 이 1MB는 썸네일을 생성하는 서버 메모리를 의미하는 것이고 실제로 생성된 파일은 압축, 인코딩 등 여러 요소로 인해 더 작은 크기를 가지게 됩니다.
        - 썸네일 크기가 1MB로 정해졌기 때문에 원본 이미지의 종횡비를 구하고, 썸네일 파일의 가로와 세로 길이를 구한 다음에 BufferedImage를 이용해 썸네일을 추출합니다.
        - 추출된 썸네일은 즉시 S3에 업로드 됩니다.
    - 만약 확장자가 이미지 타입(jpg, png 등)인데, 실제 파일 바이너리 데이터 헤더는 이미지 타입을 가리키고 있지 않은 경우, 해당 스레드 풀에 작업은 전달 되지만 imageReader가 이미지를 읽을 수 없기 때문에 예외를 던집니다.
- 썸네일 추출은 성공했지만, 그 이후 파일 업로드(complete upload 등)가 실패했을 경우, 해당 썸네일은 삭제되어야 합니다.
    - 이를 위해 파일 업로드가 실패했을 경우 uploadStatue를 FAIL로 변경하고 스케줄러에서 FAIL인 파일 메타데이터 조회 후 실제 파일 데이터와 썸네일 모두 S3에서 삭제합니다.
- 기존 파일 과업 관련한 쿼리에서 status에 관한 조건절을 추가했습니다.