### PR TITLE
[BE] 파일/폴더를 공유하면 공유 상태를 업데이트하고, 공유 링크로 접속하면 파일/폴더의 조회로 리다이렉트한다.

### DIFF
--- a/src/main/java/com/woowacamp/storage/domain/file/service/S3FileService.java
+++ b/src/main/java/com/woowacamp/storage/domain/file/service/S3FileService.java
@@ -154,7 +154,7 @@ public class S3FileService {
 		FolderMetadata folderMetadata = folderMetadataRepository.findByIdForUpdate(parentFolderId)
 			.orElseThrow(ErrorCode.FOLDER_NOT_FOUND::baseException);
 		if (!Objects.equals(folderMetadata.getCreatorId(), userId)) {
-			throw ErrorCode.NO_PERMISSION.baseException();
+			throw ACCESS_DENIED.baseException();
 		}
 	}
 

--- a/src/main/java/com/woowacamp/storage/domain/folder/service/FolderService.java
+++ b/src/main/java/com/woowacamp/storage/domain/folder/service/FolderService.java
@@ -214,7 +214,7 @@ public class FolderService {
 	 */
 	private void validatePermission(FolderMetadata folderMetadata, long userId) {
 		if (!folderMetadata.getCreatorId().equals(userId)) {
-			throw ErrorCode.NO_PERMISSION.baseException();
+			throw ErrorCode.ACCESS_DENIED.baseException();
 		}
 	}
 

--- a/src/main/java/com/woowacamp/storage/domain/shredlink/controller/SharedLinkController.java
+++ b/src/main/java/com/woowacamp/storage/domain/shredlink/controller/SharedLinkController.java
@@ -1,0 +1,26 @@
+package com.woowacamp.storage.domain.shredlink.controller;
+
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.woowacamp.storage.domain.shredlink.dto.request.MakeSharedLinkRequestDto;
+import com.woowacamp.storage.domain.shredlink.dto.response.SharedLinkResponseDto;
+import com.woowacamp.storage.domain.shredlink.service.SharedLinkService;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/share")
+public class SharedLinkController {
+
+	private final SharedLinkService sharedLinkService;
+
+	@PostMapping
+	public SharedLinkResponseDto createSharedLink(@Valid @RequestBody MakeSharedLinkRequestDto requestDto) {
+		return sharedLinkService.createSharedLink(requestDto);
+	}
+}

--- a/src/main/java/com/woowacamp/storage/domain/shredlink/controller/SharedLinkController.java
+++ b/src/main/java/com/woowacamp/storage/domain/shredlink/controller/SharedLinkController.java
@@ -1,8 +1,10 @@
 package com.woowacamp.storage.domain.shredlink.controller;
 
+import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.woowacamp.storage.domain.shredlink.dto.request.MakeSharedLinkRequestDto;
@@ -19,6 +21,7 @@ public class SharedLinkController {
 
 	private final SharedLinkService sharedLinkService;
 
+	@ResponseStatus(HttpStatus.CREATED)
 	@PostMapping
 	public SharedLinkResponseDto createSharedLink(@Valid @RequestBody MakeSharedLinkRequestDto requestDto) {
 		return sharedLinkService.createSharedLink(requestDto);

--- a/src/main/java/com/woowacamp/storage/domain/shredlink/dto/request/MakeSharedLinkRequestDto.java
+++ b/src/main/java/com/woowacamp/storage/domain/shredlink/dto/request/MakeSharedLinkRequestDto.java
@@ -1,0 +1,10 @@
+package com.woowacamp.storage.domain.shredlink.dto.request;
+
+import jakarta.validation.constraints.Positive;
+
+public record MakeSharedLinkRequestDto(
+	@Positive long userId,
+	boolean isFile,
+	@Positive long targetId
+) {
+}

--- a/src/main/java/com/woowacamp/storage/domain/shredlink/dto/request/MakeSharedLinkRequestDto.java
+++ b/src/main/java/com/woowacamp/storage/domain/shredlink/dto/request/MakeSharedLinkRequestDto.java
@@ -1,10 +1,18 @@
 package com.woowacamp.storage.domain.shredlink.dto.request;
 
+import com.woowacamp.storage.domain.shredlink.entity.PermissionType;
+
+import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Positive;
 
 public record MakeSharedLinkRequestDto(
 	@Positive long userId,
 	boolean isFile,
-	@Positive long targetId
+	@Positive long targetId,
+	@NotNull String permissionType
 ) {
+
+	public PermissionType getPermissionType() {
+		return PermissionType.fromValue(permissionType);
+	}
 }

--- a/src/main/java/com/woowacamp/storage/domain/shredlink/dto/response/SharedLinkResponseDto.java
+++ b/src/main/java/com/woowacamp/storage/domain/shredlink/dto/response/SharedLinkResponseDto.java
@@ -1,0 +1,6 @@
+package com.woowacamp.storage.domain.shredlink.dto.response;
+
+public record SharedLinkResponseDto(
+	String link
+) {
+}

--- a/src/main/java/com/woowacamp/storage/domain/shredlink/entity/PermissionType.java
+++ b/src/main/java/com/woowacamp/storage/domain/shredlink/entity/PermissionType.java
@@ -1,0 +1,22 @@
+package com.woowacamp.storage.domain.shredlink.entity;
+
+import java.util.Arrays;
+
+import com.woowacamp.storage.global.error.ErrorCode;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum PermissionType {
+	WRITE("Write"), READ("Read");
+	private final String value;
+
+	public static PermissionType fromValue(String value) {
+		return Arrays.stream(PermissionType.values())
+			.filter(type -> type.getValue().equalsIgnoreCase(value))
+			.findFirst()
+			.orElseThrow(ErrorCode.WRONG_PERMISSION_TYPE::baseException);
+	}
+}

--- a/src/main/java/com/woowacamp/storage/domain/shredlink/entity/SharedLink.java
+++ b/src/main/java/com/woowacamp/storage/domain/shredlink/entity/SharedLink.java
@@ -8,14 +8,20 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
 import jakarta.validation.constraints.NotNull;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
 @Table(
-	name = "shared_link"
+	name = "shared_link",
+	uniqueConstraints = {
+		@UniqueConstraint(columnNames = {"shared_link_url"}),
+		@UniqueConstraint(columnNames = {"shared_token"})
+	}
 )
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
@@ -30,15 +36,43 @@ public class SharedLink {
 	@NotNull
 	private LocalDateTime createdAt;
 
-	@Column(name = "metadata_id", columnDefinition = "BIGINT NOT NULL")
+	// 공유하는 링크
+	@Column(name = "shared_link_url", columnDefinition = "VARCHAR(300) NOT NULL")
 	@NotNull
-	private Long metadataId;
+	private String sharedLinkUrl;
 
-	@Column(name = "is_file_link", columnDefinition = "TINYINT NOT NULL")
+	// 공유하는 사용자의 pk
+	@Column(name = "shared_user_id", columnDefinition = "BIGINT NOT NULL")
 	@NotNull
-	private Boolean isFileLink;
+	private Long sharedUserId;
+
+	// 공유 받은 사용자를 인증할 토큰(쿠키)
+	@Column(name = "shared_token", columnDefinition = "VARCHAR(100) NOT NULL")
+	@NotNull
+	private String sharedToken;
 
 	@Column(name = "expired_at", columnDefinition = "TIMESTAMP NOT NULL")
 	@NotNull
 	private LocalDateTime expiredAt;
+
+	@Column(name = "is_file", columnDefinition = "TINYINT(1) NOT NULL")
+	@NotNull
+	private Boolean isFile;
+
+	@Column(name = "target_id", columnDefinition = "BIGINT NOT NULL")
+	@NotNull
+	private Long targetId;
+
+	@Builder
+	public SharedLink(Long id, LocalDateTime createdAt, String sharedLinkUrl, Long sharedUserId, String sharedToken,
+		LocalDateTime expiredAt, Boolean isFile, Long targetId) {
+		this.id = id;
+		this.createdAt = createdAt;
+		this.sharedLinkUrl = sharedLinkUrl;
+		this.sharedUserId = sharedUserId;
+		this.sharedToken = sharedToken;
+		this.expiredAt = expiredAt;
+		this.isFile = isFile;
+		this.targetId = targetId;
+	}
 }

--- a/src/main/java/com/woowacamp/storage/domain/shredlink/entity/SharedLink.java
+++ b/src/main/java/com/woowacamp/storage/domain/shredlink/entity/SharedLink.java
@@ -4,6 +4,8 @@ import java.time.LocalDateTime;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
@@ -63,9 +65,15 @@ public class SharedLink {
 	@NotNull
 	private Long targetId;
 
+	@Column(name = "permission_type", columnDefinition = "VARCHAR(10) NOT NULL")
+	@NotNull
+	@Enumerated(EnumType.STRING)
+	private PermissionType permissionType;
+
 	@Builder
+
 	public SharedLink(Long id, LocalDateTime createdAt, String sharedLinkUrl, Long sharedUserId, String sharedToken,
-		LocalDateTime expiredAt, Boolean isFile, Long targetId) {
+		LocalDateTime expiredAt, Boolean isFile, Long targetId, PermissionType permissionType) {
 		this.id = id;
 		this.createdAt = createdAt;
 		this.sharedLinkUrl = sharedLinkUrl;
@@ -74,5 +82,6 @@ public class SharedLink {
 		this.expiredAt = expiredAt;
 		this.isFile = isFile;
 		this.targetId = targetId;
+		this.permissionType = permissionType;
 	}
 }

--- a/src/main/java/com/woowacamp/storage/domain/shredlink/entity/SharedLink.java
+++ b/src/main/java/com/woowacamp/storage/domain/shredlink/entity/SharedLink.java
@@ -18,13 +18,8 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
-@Table(
-	name = "shared_link",
-	uniqueConstraints = {
-		@UniqueConstraint(columnNames = {"shared_link_url"}),
-		@UniqueConstraint(columnNames = {"shared_token"})
-	}
-)
+@Table(name = "shared_link", uniqueConstraints = {@UniqueConstraint(columnNames = {"shared_link_url"}),
+	@UniqueConstraint(columnNames = {"shared_token"})})
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
 public class SharedLink {
@@ -71,7 +66,6 @@ public class SharedLink {
 	private PermissionType permissionType;
 
 	@Builder
-
 	public SharedLink(Long id, LocalDateTime createdAt, String sharedLinkUrl, Long sharedUserId, String sharedToken,
 		LocalDateTime expiredAt, Boolean isFile, Long targetId, PermissionType permissionType) {
 		this.id = id;

--- a/src/main/java/com/woowacamp/storage/domain/shredlink/entity/SharedLinkFactory.java
+++ b/src/main/java/com/woowacamp/storage/domain/shredlink/entity/SharedLinkFactory.java
@@ -1,0 +1,24 @@
+package com.woowacamp.storage.domain.shredlink.entity;
+
+import java.time.LocalDateTime;
+
+import com.woowacamp.storage.domain.shredlink.dto.request.MakeSharedLinkRequestDto;
+import com.woowacamp.storage.global.constant.CommonConstant;
+
+public class SharedLinkFactory {
+	public static SharedLink createSharedLink(MakeSharedLinkRequestDto requestDto, String sharedUrl,
+		String sharedToken) {
+		LocalDateTime createTime = LocalDateTime.now();
+		LocalDateTime expiredTime = createTime.plusHours(CommonConstant.SHARED_LINK_VALID_TIME);
+		return SharedLink.builder()
+			.createdAt(createTime)
+			.sharedLinkUrl(sharedUrl)
+			.sharedUserId(requestDto.userId())
+			.sharedToken(sharedToken)
+			.expiredAt(expiredTime)
+			.isFile(requestDto.isFile())
+			.targetId(requestDto.targetId())
+			.permissionType(requestDto.getPermissionType())
+			.build();
+	}
+}

--- a/src/main/java/com/woowacamp/storage/domain/shredlink/service/SharedLinkService.java
+++ b/src/main/java/com/woowacamp/storage/domain/shredlink/service/SharedLinkService.java
@@ -66,6 +66,7 @@ public class SharedLinkService {
 			.expiredAt(expiredTime)
 			.isFile(requestDto.isFile())
 			.targetId(requestDto.targetId())
+			.permissionType(requestDto.getPermissionType())
 			.build();
 
 		try {

--- a/src/main/java/com/woowacamp/storage/domain/shredlink/service/SharedLinkService.java
+++ b/src/main/java/com/woowacamp/storage/domain/shredlink/service/SharedLinkService.java
@@ -1,6 +1,5 @@
 package com.woowacamp.storage.domain.shredlink.service;
 
-import java.time.LocalDateTime;
 import java.util.UUID;
 
 import org.springframework.beans.factory.annotation.Value;
@@ -15,6 +14,7 @@ import com.woowacamp.storage.domain.folder.repository.FolderMetadataRepository;
 import com.woowacamp.storage.domain.shredlink.dto.request.MakeSharedLinkRequestDto;
 import com.woowacamp.storage.domain.shredlink.dto.response.SharedLinkResponseDto;
 import com.woowacamp.storage.domain.shredlink.entity.SharedLink;
+import com.woowacamp.storage.domain.shredlink.entity.SharedLinkFactory;
 import com.woowacamp.storage.domain.shredlink.repository.SharedLinkRepository;
 import com.woowacamp.storage.global.constant.CommonConstant;
 import com.woowacamp.storage.global.error.ErrorCode;
@@ -53,21 +53,9 @@ public class SharedLinkService {
 			}
 		}
 
-		LocalDateTime createTime = LocalDateTime.now();
-		LocalDateTime expiredTime = createTime.plusHours(CommonConstant.SHARED_LINK_VALID_TIME);
-
 		String sharedUrl = createSharedLink();
 		String sharedToken = createToken();
-		SharedLink sharedLink = SharedLink.builder()
-			.createdAt(createTime)
-			.sharedLinkUrl(sharedUrl)
-			.sharedUserId(requestDto.userId())
-			.sharedToken(sharedToken)
-			.expiredAt(expiredTime)
-			.isFile(requestDto.isFile())
-			.targetId(requestDto.targetId())
-			.permissionType(requestDto.getPermissionType())
-			.build();
+		SharedLink sharedLink = SharedLinkFactory.createSharedLink(requestDto, sharedUrl, sharedToken);
 
 		try {
 			sharedLinkRepository.saveAndFlush(sharedLink);

--- a/src/main/java/com/woowacamp/storage/domain/shredlink/service/SharedLinkService.java
+++ b/src/main/java/com/woowacamp/storage/domain/shredlink/service/SharedLinkService.java
@@ -1,0 +1,91 @@
+package com.woowacamp.storage.domain.shredlink.service;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.woowacamp.storage.domain.file.entity.FileMetadata;
+import com.woowacamp.storage.domain.file.repository.FileMetadataJpaRepository;
+import com.woowacamp.storage.domain.folder.entity.FolderMetadata;
+import com.woowacamp.storage.domain.folder.repository.FolderMetadataRepository;
+import com.woowacamp.storage.domain.shredlink.dto.request.MakeSharedLinkRequestDto;
+import com.woowacamp.storage.domain.shredlink.dto.response.SharedLinkResponseDto;
+import com.woowacamp.storage.domain.shredlink.entity.SharedLink;
+import com.woowacamp.storage.domain.shredlink.repository.SharedLinkRepository;
+import com.woowacamp.storage.global.constant.CommonConstant;
+import com.woowacamp.storage.global.error.ErrorCode;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class SharedLinkService {
+	@Value("${share.server-domain}")
+	private String SERVER_DOMAIN;
+
+	private final SharedLinkRepository sharedLinkRepository;
+	private final FolderMetadataRepository folderMetadataRepository;
+	private final FileMetadataJpaRepository fileMetadataJpaRepository;
+
+	/**
+	 * 공유 링크 생성 메소드
+	 * 공유 링크와 토큰 값은 UUID를 사용했습니다.
+	 */
+	@Transactional
+	public SharedLinkResponseDto createSharedLink(MakeSharedLinkRequestDto requestDto) {
+		if (requestDto.isFile()) { // file인 경우
+			FileMetadata fileMetadata = fileMetadataJpaRepository.findById(requestDto.targetId())
+				.orElseThrow(ErrorCode.FILE_NOT_FOUND::baseException);
+
+			if (!isOwner(fileMetadata.getOwnerId(), requestDto.userId())) {
+				throw ErrorCode.ACCESS_DENIED.baseException();
+			}
+		} else { // folder인 경우
+			FolderMetadata folderMetadata = folderMetadataRepository.findById(requestDto.targetId())
+				.orElseThrow(ErrorCode.FOLDER_NOT_FOUND::baseException);
+
+			if (!isOwner(folderMetadata.getOwnerId(), requestDto.userId())) {
+				throw ErrorCode.ACCESS_DENIED.baseException();
+			}
+		}
+
+		LocalDateTime createTime = LocalDateTime.now();
+		LocalDateTime expiredTime = createTime.plusHours(CommonConstant.SHARED_LINK_VALID_TIME);
+
+		String sharedUrl = createSharedLink();
+		String sharedToken = createToken();
+		SharedLink sharedLink = SharedLink.builder()
+			.createdAt(createTime)
+			.sharedLinkUrl(sharedUrl)
+			.sharedUserId(requestDto.userId())
+			.sharedToken(sharedToken)
+			.expiredAt(expiredTime)
+			.isFile(requestDto.isFile())
+			.targetId(requestDto.targetId())
+			.build();
+
+		try {
+			sharedLinkRepository.saveAndFlush(sharedLink);
+		} catch (DataIntegrityViolationException e) {
+			throw ErrorCode.DUPLICATED_SHARED_LINK.baseException();
+		}
+
+		return new SharedLinkResponseDto(sharedUrl);
+	}
+
+	private boolean isOwner(long ownerId, long userId) {
+		return ownerId == userId;
+	}
+
+	private String createSharedLink() {
+		return SERVER_DOMAIN + CommonConstant.SHARED_URI + UUID.randomUUID();
+	}
+
+	private String createToken() {
+		return UUID.randomUUID().toString();
+	}
+}

--- a/src/main/java/com/woowacamp/storage/global/constant/CommonConstant.java
+++ b/src/main/java/com/woowacamp/storage/global/constant/CommonConstant.java
@@ -8,4 +8,6 @@ public class CommonConstant {
 	public static final int FILE_WRITER_KEEP_ALIVE_TIME = 10;
 	public static final int FILE_WRITER_QUEUE_SIZE = 400;
 	public static final int ORPHAN_PARENT_ID = -1;
+	public static final long SHARED_LINK_VALID_TIME = 3;
+	public static final String SHARED_URI = "/api/v1/share?shareId=";
 }

--- a/src/main/java/com/woowacamp/storage/global/error/ErrorCode.java
+++ b/src/main/java/com/woowacamp/storage/global/error/ErrorCode.java
@@ -32,6 +32,7 @@ public enum ErrorCode {
 	UNABLE_TO_CREATE_FILE(HttpStatus.BAD_REQUEST, "해당 위치에 파일을 생성할 수 없습니다."),
 	CANNOT_DELETE_FILE_WHEN_UPLOADING(HttpStatus.BAD_REQUEST, "파일 업로드 중에 폴더 삭제를 할 수 없습니다."),
 	INVALID_MULTIPART_FORM_DATA(HttpStatus.BAD_REQUEST, "올바른 데이터 형식으로 요청을 보내주세요."),
+	DUPLICATED_SHARED_LINK(HttpStatus.CONFLICT, "공유 링크 생성에 실패했습니다. 잠시 후에 다시 시도해 주세요."),
 	// 500,
 	FILE_UPLOAD_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "파일 업로드에 실패했습니다."),
 	FILE_DELETE_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "파일 삭제에 실패했습니다.");

--- a/src/main/java/com/woowacamp/storage/global/error/ErrorCode.java
+++ b/src/main/java/com/woowacamp/storage/global/error/ErrorCode.java
@@ -16,7 +16,6 @@ public enum ErrorCode {
 	WRONG_FOLDER_CONTENTS_SORT_FIELD(HttpStatus.BAD_REQUEST, "잘못된 폴더 컨텐츠 정렬 기준입니다."),
 	WRONG_PAGE_SIZE(HttpStatus.BAD_REQUEST, "잘못된 페이지 사이즈입니다."),
 	INVALID_FILE_NAME(HttpStatus.BAD_REQUEST, "파일 이름이 부적절합니다."),
-	NO_PERMISSION(HttpStatus.FORBIDDEN, "권한이 부족합니다."),
 	EXCEED_MAX_FILE_SIZE(HttpStatus.BAD_REQUEST, "요청 가능한 파일 크기를 초과했습니다."),
 	EXCEED_MAX_STORAGE_SIZE(HttpStatus.BAD_REQUEST, "최대 저장 공간 크기를 초과했습니다."),
 	INVALID_INPUT_VALUE(HttpStatus.BAD_REQUEST, "올바르지 않은 입력입니다."),

--- a/src/main/java/com/woowacamp/storage/global/error/ErrorCode.java
+++ b/src/main/java/com/woowacamp/storage/global/error/ErrorCode.java
@@ -33,6 +33,7 @@ public enum ErrorCode {
 	CANNOT_DELETE_FILE_WHEN_UPLOADING(HttpStatus.BAD_REQUEST, "파일 업로드 중에 폴더 삭제를 할 수 없습니다."),
 	INVALID_MULTIPART_FORM_DATA(HttpStatus.BAD_REQUEST, "올바른 데이터 형식으로 요청을 보내주세요."),
 	DUPLICATED_SHARED_LINK(HttpStatus.CONFLICT, "공유 링크 생성에 실패했습니다. 잠시 후에 다시 시도해 주세요."),
+	WRONG_PERMISSION_TYPE(HttpStatus.BAD_REQUEST, "잘못된 권한 타입입니다."),
 	// 500,
 	FILE_UPLOAD_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "파일 업로드에 실패했습니다."),
 	FILE_DELETE_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "파일 삭제에 실패했습니다.");

--- a/src/main/java/com/woowacamp/storage/global/error/GlobalExceptionHandler.java
+++ b/src/main/java/com/woowacamp/storage/global/error/GlobalExceptionHandler.java
@@ -9,7 +9,6 @@ import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.MissingServletRequestParameterException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
-import org.springframework.web.method.annotation.HandlerMethodValidationException;
 import org.springframework.web.servlet.resource.NoResourceFoundException;
 
 import com.woowacamp.storage.global.response.ErrorResponse;
@@ -67,7 +66,7 @@ public class GlobalExceptionHandler {
 		return ResponseEntity.status(errorResponse.httpStatus()).body(errorResponse);
 	}
 
-	@ExceptionHandler(HandlerMethodValidationException.class)
+	@ExceptionHandler(MethodArgumentNotValidException.class)
 	public ResponseEntity<ErrorResponse> handleHandlerMethodValidationException(MethodArgumentNotValidException e) {
 		CustomException customException = ErrorCode.INVALID_ARGUMENT_ERROR.baseException();
 		ErrorResponse errorResponse = ErrorResponse.of(customException.getHttpStatus(), customException.getMessage(),

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -20,3 +20,6 @@ spring:
     multipart:
       enabled: false
       resolve-lazily: true
+
+share:
+  server-domain: localhost:8080


### PR DESCRIPTION
- resolves #22 

### 🚀 어떤 기능을 구현했나요 ?
1. 파일/폴더를 공유하면 공유 상태를 수정하고 공유 링크를 반환한다.
   - 이미 해당 요소에 대해서 같은 권한을 부여하는 공유 링크가 생성되어 있다면 기존 링크 바로 반환
3. 파일/폴더의 공유를 취소하면 공유 상태를 취소로 수정한다.
4. 공유 링크로 접속하면 파일 및 폴더 조회 페이지로 리다이렉트한다.

### 🔥 어떻게 해결했나요 ?
1. 테이블  스키마 수정
- 파일 및 폴더 엔티티에 공유 관련 필드 추가(isShared, sharingExpiredAt, permissionType)
2. 이벤트 리스너 사용해서 비동기적으로 공유 상태 수정하여 응답 속도 향상
- 공유 요청이 오면 이벤트를 발행하고 응답
- 이벤트 핸들러는 기존 트랜잭션이 커밋 된 후 새로운 트랜잭션에서 응답 상태 업데이트. 폴더에 대한 요청이라면 하위 폴더 및 파일의 공유 상태 업데이트.
- CTE를 사용해서 수정해야할 id 리스트를 먼저 조회후 IN절을 사용해서 하나의 쿼리로 업데이트
3. 공유 링크로 접속시마다 새로 리다이렉트 주소를 만들지 않기 위해서 db에 필드로 추가
4. 기존에 생성된 공유 링크가 있는지 확인해서 없는 경우에만 새로 생성
- 이미 생성된 링크가 있다면 해당 권한으로 폴더/파일의 공유 상태가 업데이트가 완료된 상태로 다시 UPDATE할 필요 없음.
5. 폴더 조회시 사용하는 `GetFolderContentsRequestParam`의 default값 추가
- 공유 링크 접속 후 리다이렉트시에 쿼리 스트링을 붙이지 않기 때문에 컨트롤러에서 기본값 추가
6. 폴더 및 파일 생성시 부모 폴더의 권한 상속
- owner는 부모 폴더의 owner, creator는 요청한 사용자
### 📝 어떤 부분에 집중해서 리뷰해야 할까요?


### 📚 참고 자료, 할 말
- 현재 비동기 요청이 실패해서 롤백된다면 폴더와 파일의 공유 상태가 업데이트 안되는 문제가 있습니다. 추후 수정이 필요합니다. 