### PR TITLE
[BE] 조회 및 이동시 공유 권한 체크 추가

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - hot-fix
 
 jobs:
   deploy:

--- a/build.gradle
+++ b/build.gradle
@@ -41,6 +41,10 @@ dependencies {
 	annotationProcessor "com.querydsl:querydsl-apt:5.0.0:jakarta"
 	annotationProcessor "jakarta.annotation:jakarta.annotation-api"
 	annotationProcessor "jakarta.persistence:jakarta.persistence-api"
+
+	// grafana
+	implementation 'org.springframework.boot:spring-boot-starter-actuator'
+	implementation 'io.micrometer:micrometer-registry-prometheus'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/woowacamp/storage/domain/file/entity/FileMetadata.java
+++ b/src/main/java/com/woowacamp/storage/domain/file/entity/FileMetadata.java
@@ -161,6 +161,6 @@ public class FileMetadata {
 	}
 
 	public boolean isSharingExpired() {
-		return permissionType != PermissionType.NONE && sharingExpiredAt.isBefore(LocalDateTime.now());
+		return sharingExpiredAt.isBefore(LocalDateTime.now());
 	}
 }

--- a/src/main/java/com/woowacamp/storage/domain/file/entity/FileMetadata.java
+++ b/src/main/java/com/woowacamp/storage/domain/file/entity/FileMetadata.java
@@ -4,7 +4,6 @@ import java.time.LocalDateTime;
 
 import com.woowacamp.storage.global.constant.CommonConstant;
 import com.woowacamp.storage.global.constant.PermissionType;
-import com.woowacamp.storage.global.constant.PermissionType;
 import com.woowacamp.storage.global.constant.UploadStatus;
 
 import jakarta.persistence.Column;
@@ -110,7 +109,7 @@ public class FileMetadata {
 		String thumbnailUUID,
 		LocalDateTime sharingExpiredAt,
 		PermissionType permissionType
-		) {
+	) {
 		this.id = id;
 		this.rootId = rootId;
 		this.creatorId = creatorId;
@@ -159,5 +158,9 @@ public class FileMetadata {
 	public void cancelShare() {
 		this.permissionType = PermissionType.NONE;
 		this.sharingExpiredAt = CommonConstant.UNAVAILABLE_TIME;
+	}
+
+	public boolean isSharingExpired() {
+		return sharingExpiredAt.isBefore(LocalDateTime.now());
 	}
 }

--- a/src/main/java/com/woowacamp/storage/domain/file/entity/FileMetadata.java
+++ b/src/main/java/com/woowacamp/storage/domain/file/entity/FileMetadata.java
@@ -161,6 +161,6 @@ public class FileMetadata {
 	}
 
 	public boolean isSharingExpired() {
-		return sharingExpiredAt.isBefore(LocalDateTime.now());
+		return permissionType != PermissionType.NONE && sharingExpiredAt.isBefore(LocalDateTime.now());
 	}
 }

--- a/src/main/java/com/woowacamp/storage/domain/file/event/FileMoveEvent.java
+++ b/src/main/java/com/woowacamp/storage/domain/file/event/FileMoveEvent.java
@@ -1,0 +1,20 @@
+package com.woowacamp.storage.domain.file.event;
+
+import org.springframework.context.ApplicationEvent;
+
+import com.woowacamp.storage.domain.file.entity.FileMetadata;
+import com.woowacamp.storage.domain.folder.entity.FolderMetadata;
+
+import lombok.Getter;
+
+@Getter
+public class FileMoveEvent extends ApplicationEvent {
+	private final FileMetadata sourceFile;
+	private final FolderMetadata targetFolder;
+
+	public FileMoveEvent(Object source, FileMetadata sourceFile, FolderMetadata targetFolder) {
+		super(source);
+		this.sourceFile = sourceFile;
+		this.targetFolder = targetFolder;
+	}
+}

--- a/src/main/java/com/woowacamp/storage/domain/file/event/FileMoveEventListener.java
+++ b/src/main/java/com/woowacamp/storage/domain/file/event/FileMoveEventListener.java
@@ -1,0 +1,20 @@
+package com.woowacamp.storage.domain.file.event;
+
+import org.springframework.context.event.EventListener;
+import org.springframework.stereotype.Component;
+
+import com.woowacamp.storage.domain.shredlink.service.SharedLinkService;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class FileMoveEventListener {
+	private final SharedLinkService sharingService;
+
+	@EventListener
+	public void updateSubSharingStatus(FileMoveEvent moveEvent) {
+		sharingService.updateFileShareStatus(moveEvent.getSourceFile().getId(),
+			moveEvent.getTargetFolder().getPermissionType(), moveEvent.getTargetFolder().getSharingExpiredAt());
+	}
+}

--- a/src/main/java/com/woowacamp/storage/domain/folder/controller/FolderController.java
+++ b/src/main/java/com/woowacamp/storage/domain/folder/controller/FolderController.java
@@ -60,8 +60,8 @@ public class FolderController {
 	@PatchMapping("/{folderId}")
 	public void moveFolder(@PathVariable("folderId") @CheckField(value = FieldType.FOLDER_ID) Long sourceFolderId,
 		@CheckDto @RequestBody FolderMoveDto dto) {
-		folderService.checkFolderOwnedBy(sourceFolderId, dto.userId());
-		folderService.checkFolderOwnedBy(dto.targetFolderId(), dto.userId());
+		// folderService.checkFolderOwnedBy(sourceFolderId, dto.userId());
+		// folderService.checkFolderOwnedBy(dto.targetFolderId(), dto.userId());
 		folderService.moveFolder(sourceFolderId, dto);
 	}
 

--- a/src/main/java/com/woowacamp/storage/domain/folder/controller/FolderController.java
+++ b/src/main/java/com/woowacamp/storage/domain/folder/controller/FolderController.java
@@ -1,5 +1,7 @@
 package com.woowacamp.storage.domain.folder.controller;
 
+import java.util.Objects;
+
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -53,7 +55,8 @@ public class FolderController {
 		folderService.checkFolderOwnedBy(folderId, request.userId());
 
 		return folderService.getFolderContents(folderId, request.cursorId(), request.cursorType(), request.limit(),
-			request.sortBy(), request.sortDirection(), request.localDateTime(), request.size());
+			request.sortBy(), request.sortDirection(), request.localDateTime(), request.size(),
+			Objects.equals(request.userId(), request.creatorId()));
 	}
 
 	@RequestType(permission = PermissionType.WRITE, fileType = FileType.FOLDER)

--- a/src/main/java/com/woowacamp/storage/domain/folder/dto/GetFolderContentsRequestParams.java
+++ b/src/main/java/com/woowacamp/storage/domain/folder/dto/GetFolderContentsRequestParams.java
@@ -15,7 +15,8 @@ import jakarta.validation.constraints.Positive;
 public record GetFolderContentsRequestParams(@NotNull @Positive @CheckField(value = FieldType.USER_ID) Long userId,
 											 @NotNull @Positive Long cursorId, @NotNull CursorType cursorType,
 											 @Positive @Max(MAX_SIZE) Integer limit, FolderContentsSortField sortBy,
-											 Sort.Direction sortDirection, LocalDateTime localDateTime, Long size) {
+											 Sort.Direction sortDirection, LocalDateTime localDateTime, Long size,
+											 @CheckField(FieldType.CREATOR_ID) Long creatorId) {
 	private static final int MAX_SIZE = 1000;
 	private static final int DEFAULT_SIZE = 100;
 

--- a/src/main/java/com/woowacamp/storage/domain/folder/entity/FolderMetadata.java
+++ b/src/main/java/com/woowacamp/storage/domain/folder/entity/FolderMetadata.java
@@ -121,6 +121,6 @@ public class FolderMetadata {
 	}
 
 	public boolean isSharingExpired() {
-		return permissionType != PermissionType.NONE && sharingExpiredAt.isBefore(LocalDateTime.now());
+		return sharingExpiredAt.isBefore(LocalDateTime.now());
 	}
 }

--- a/src/main/java/com/woowacamp/storage/domain/folder/entity/FolderMetadata.java
+++ b/src/main/java/com/woowacamp/storage/domain/folder/entity/FolderMetadata.java
@@ -121,6 +121,6 @@ public class FolderMetadata {
 	}
 
 	public boolean isSharingExpired() {
-		return sharingExpiredAt.isBefore(LocalDateTime.now());
+		return permissionType != PermissionType.NONE && sharingExpiredAt.isBefore(LocalDateTime.now());
 	}
 }

--- a/src/main/java/com/woowacamp/storage/domain/folder/entity/FolderMetadata.java
+++ b/src/main/java/com/woowacamp/storage/domain/folder/entity/FolderMetadata.java
@@ -119,4 +119,8 @@ public class FolderMetadata {
 		this.permissionType = PermissionType.NONE;
 		this.sharingExpiredAt = CommonConstant.UNAVAILABLE_TIME;
 	}
+
+	public boolean isSharingExpired() {
+		return sharingExpiredAt.isBefore(LocalDateTime.now());
+	}
 }

--- a/src/main/java/com/woowacamp/storage/domain/folder/event/FolderMoveEvent.java
+++ b/src/main/java/com/woowacamp/storage/domain/folder/event/FolderMoveEvent.java
@@ -1,0 +1,19 @@
+package com.woowacamp.storage.domain.folder.event;
+
+import org.springframework.context.ApplicationEvent;
+
+import com.woowacamp.storage.domain.folder.entity.FolderMetadata;
+
+import lombok.Getter;
+
+@Getter
+public class FolderMoveEvent extends ApplicationEvent {
+	private final FolderMetadata sourceFolder;
+	private final FolderMetadata targetFolder;
+
+	public FolderMoveEvent(Object source, FolderMetadata sourceFolder, FolderMetadata targetFolder) {
+		super(source);
+		this.sourceFolder = sourceFolder;
+		this.targetFolder = targetFolder;
+	}
+}

--- a/src/main/java/com/woowacamp/storage/domain/folder/event/FolderMoveEventListener.java
+++ b/src/main/java/com/woowacamp/storage/domain/folder/event/FolderMoveEventListener.java
@@ -1,0 +1,20 @@
+package com.woowacamp.storage.domain.folder.event;
+
+import org.springframework.context.event.EventListener;
+import org.springframework.stereotype.Component;
+
+import com.woowacamp.storage.domain.shredlink.service.SharedLinkService;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class FolderMoveEventListener {
+	private final SharedLinkService sharingService;
+
+	@EventListener
+	public void updateSubSharingStatus(FolderMoveEvent moveEvent) {
+		sharingService.updateFolderSharingStatus(moveEvent.getSourceFolder().getId(),
+			moveEvent.getTargetFolder().getPermissionType(), moveEvent.getTargetFolder().getSharingExpiredAt());
+	}
+}

--- a/src/main/java/com/woowacamp/storage/domain/shredlink/entity/SharedLinkFactory.java
+++ b/src/main/java/com/woowacamp/storage/domain/shredlink/entity/SharedLinkFactory.java
@@ -10,7 +10,7 @@ public class SharedLinkFactory {
 	public static SharedLink createSharedLink(MakeSharedLinkRequestDto requestDto, String sharedId,
 		String redirectUrl) {
 		LocalDateTime createTime = LocalDateTime.now();
-		LocalDateTime expiredTime = createTime.plusSeconds(CommonConstant.SHARED_LINK_VALID_TIME);
+		LocalDateTime expiredTime = createTime.plusHours(CommonConstant.SHARED_LINK_VALID_TIME);
 		return SharedLink.builder()
 			.createdAt(createTime)
 			.redirectUrl(redirectUrl)

--- a/src/main/java/com/woowacamp/storage/domain/shredlink/service/SharedLinkService.java
+++ b/src/main/java/com/woowacamp/storage/domain/shredlink/service/SharedLinkService.java
@@ -123,7 +123,7 @@ public class SharedLinkService {
 			updateFileShareStatus(sharedLink.getTargetId(), sharedLink.getPermissionType(),
 				sharedLink.getExpiredAt());
 		} else {
-			updateSubFolderShareStatus(sharedLink.getTargetId(),
+			updateFolderSharingStatus(sharedLink.getTargetId(),
 				sharedLink.getPermissionType(), sharedLink.getExpiredAt());
 		}
 	}
@@ -134,11 +134,10 @@ public class SharedLinkService {
 		fileMetadata.updateShareStatus(permissionType, sharingExpireAt);
 	}
 
-	public void updateSubFolderShareStatus(Long folderId, PermissionType permissionType,
+	public void updateFolderSharingStatus(Long folderId, PermissionType permissionType,
 		LocalDateTime sharingExpireAt) {
-		FolderMetadata folder = folderMetadataRepository.findById(folderId)
+		folderMetadataRepository.findById(folderId)
 			.orElseThrow(ErrorCode.FILE_NOT_FOUND::baseException);
-		folder.cancelShare();
 
 		Stack<Long> folderIdStack = new Stack<>();
 		folderIdStack.push(folderId);
@@ -194,7 +193,6 @@ public class SharedLinkService {
 	public void cancelFolderShare(Long folderId) {
 		FolderMetadata folder = folderMetadataRepository.findById(folderId)
 			.orElseThrow(ErrorCode.FILE_NOT_FOUND::baseException);
-		folder.cancelShare();
 
 		Stack<Long> folderIdStack = new Stack<>();
 		folderIdStack.push(folderId);

--- a/src/main/java/com/woowacamp/storage/global/aop/PermissionHandler.java
+++ b/src/main/java/com/woowacamp/storage/global/aop/PermissionHandler.java
@@ -154,12 +154,18 @@ public class PermissionHandler {
 		Long userId, PermissionType sharedPermissionType, PermissionType permissionType) {
 		// 공유 기한이 지났는데 파일에 대한 소유주가 아닌 경우 예외를 반환한다.
 		if (sharingExpiredAt.isBefore(now) && !Objects.equals(userId, ownerId)) {
+			log.error(
+				"[SharingExpired Exception] 권한 검증 중, 공유 기한이 지나고 파일 소유주가 아닌 예외 발생. request user id = {}, file owner id = {}",
+				userId, ownerId);
 			throw ErrorCode.ACCESS_DENIED.baseException();
 		}
 
 		// 읽기 권한만 있는 파일에 쓰기 작업을 시도하면 예외를 반환한다.
 		if (Objects.equals(permissionType, PermissionType.WRITE) && Objects.equals(sharedPermissionType,
 			PermissionType.READ)) {
+			log.error(
+				"[PermissionType Exception] 읽기 권한이 있는 사용자가 쓰기 권한 요청하여 예외 발생.request user id = {}, file owner id = {}",
+				userId, ownerId);
 			throw ErrorCode.ACCESS_DENIED.baseException();
 		}
 	}

--- a/src/main/java/com/woowacamp/storage/global/aop/PermissionHandler.java
+++ b/src/main/java/com/woowacamp/storage/global/aop/PermissionHandler.java
@@ -160,9 +160,9 @@ public class PermissionHandler {
 			throw ErrorCode.ACCESS_DENIED.baseException();
 		}
 
-		// 읽기 권한만 있는 파일에 쓰기 작업을 시도하면 예외를 반환한다.
-		if (Objects.equals(permissionType, PermissionType.WRITE) && Objects.equals(sharedPermissionType,
-			PermissionType.READ)) {
+		// 소유주가 아닌데 읽기 권한만 있는 파일에 쓰기 작업을 시도하면 예외를 반환한다.
+		if (!Objects.equals(userId, ownerId) && Objects.equals(permissionType, PermissionType.WRITE) && Objects.equals(
+			sharedPermissionType, PermissionType.READ)) {
 			log.error(
 				"[PermissionType Exception] 읽기 권한이 있는 사용자가 쓰기 권한 요청하여 예외 발생.request user id = {}, file owner id = {}",
 				userId, ownerId);

--- a/src/main/java/com/woowacamp/storage/global/constant/CommonConstant.java
+++ b/src/main/java/com/woowacamp/storage/global/constant/CommonConstant.java
@@ -16,7 +16,7 @@ public class CommonConstant {
 	public static final long SHARED_LINK_VALID_TIME = 3;
 	// 1MB
 	public static final int THUMBNAIL_SIZE = 1024 * 1024;
-	public static final LocalDateTime UNAVAILABLE_TIME = LocalDateTime.of(1970, 1, 1, 1, 0);
+	public static final LocalDateTime UNAVAILABLE_TIME = LocalDateTime.of(1971, 1, 1, 1, 0);
 	public static final String SHARED_LINK_URI = "/api/v1/share?sharedId=";
 	public static final String FOLDER_READ_URI = "/api/v1/folders/";
 	public static final String FILE_READ_URI = "/api/v1/files/";

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -21,5 +21,20 @@ spring:
       enabled: false
       resolve-lazily: true
 
+management:
+  endpoints:
+    web:
+      exposure:
+        include: prometheus
+  endpoint:
+    metrics:
+      enabled: true
+    prometheus:
+      enabled: true
+  prometheus:
+    metrics:
+      export:
+        enabled: true
+
 share:
   server-domain: localhost:8080

--- a/src/test/java/com/woowacamp/storage/domain/folder/service/FolderServiceTest.java
+++ b/src/test/java/com/woowacamp/storage/domain/folder/service/FolderServiceTest.java
@@ -105,20 +105,20 @@ class FolderServiceTest {
 			void orderByCreatedAt_asc() {
 				// When
 				FolderContentsDto result = folderService.getFolderContents(parentFolder.getId(), 0L, CursorType.FILE,
-					10, FolderContentsSortField.CREATED_AT, Sort.Direction.ASC, now.minusDays(7), 0L);
+					10, FolderContentsSortField.CREATED_AT, Sort.Direction.ASC, now.minusDays(7), 0L, true);
 
 				// Then
 				assertEquals(7, result.fileMetadataList().size());
 				assertTrue(result.folderMetadataList().isEmpty());
 				for (int i = 0; i < result.fileMetadataList().size() - 1; i++) {
 					assertTrue(result.fileMetadataList()
-								   .get(i)
-								   .getCreatedAt()
-								   .isBefore(result.fileMetadataList().get(i + 1).getCreatedAt())
-							   || result.fileMetadataList()
-								   .get(i)
-								   .getCreatedAt()
-								   .equals(result.fileMetadataList().get(i + 1).getCreatedAt()));
+						.get(i)
+						.getCreatedAt()
+						.isBefore(result.fileMetadataList().get(i + 1).getCreatedAt())
+						|| result.fileMetadataList()
+						.get(i)
+						.getCreatedAt()
+						.equals(result.fileMetadataList().get(i + 1).getCreatedAt()));
 				}
 			}
 
@@ -127,7 +127,7 @@ class FolderServiceTest {
 			void orderBySize_desc() {
 				// When
 				FolderContentsDto result = folderService.getFolderContents(parentFolder.getId(), 0L, CursorType.FILE,
-					10, FolderContentsSortField.DATA_SIZE, Sort.Direction.ASC, now, 0L);
+					10, FolderContentsSortField.DATA_SIZE, Sort.Direction.ASC, now, 0L, true);
 
 				// Then
 				assertEquals(7, result.fileMetadataList().size());
@@ -140,7 +140,7 @@ class FolderServiceTest {
 				// When
 				int limit = 5;
 				FolderContentsDto result = folderService.getFolderContents(parentFolder.getId(), 0L, CursorType.FILE,
-					limit, FolderContentsSortField.CREATED_AT, Sort.Direction.DESC, now, 0L);
+					limit, FolderContentsSortField.CREATED_AT, Sort.Direction.DESC, now, 0L, true);
 
 				// Then
 				assertEquals(limit, result.fileMetadataList().size());
@@ -157,7 +157,7 @@ class FolderServiceTest {
 			void orderByCreatedAt_desc() {
 				// When
 				FolderContentsDto result = folderService.getFolderContents(parentFolder.getId(), 0L, CursorType.FOLDER,
-					20, FolderContentsSortField.CREATED_AT, Sort.Direction.DESC, now, 0L);
+					20, FolderContentsSortField.CREATED_AT, Sort.Direction.DESC, now, 0L, true);
 
 				// Then
 				List<FolderMetadata> resultFolders = result.folderMetadataList();
@@ -166,11 +166,11 @@ class FolderServiceTest {
 				assertEquals(7, resultFiles.size());
 				for (int i = 0; i < resultFolders.size() - 1; i++) {
 					assertTrue(resultFolders.get(i).getCreatedAt().isAfter(resultFolders.get(i + 1).getCreatedAt())
-							   || resultFolders.get(i).getCreatedAt().equals(resultFolders.get(i + 1).getCreatedAt()));
+						|| resultFolders.get(i).getCreatedAt().equals(resultFolders.get(i + 1).getCreatedAt()));
 				}
 				for (int i = 0; i < resultFiles.size() - 1; i++) {
 					assertTrue(resultFiles.get(i).getCreatedAt().isAfter(resultFiles.get(i + 1).getCreatedAt())
-							   || resultFiles.get(i).getCreatedAt().equals(resultFiles.get(i + 1).getCreatedAt()));
+						|| resultFiles.get(i).getCreatedAt().equals(resultFiles.get(i + 1).getCreatedAt()));
 				}
 			}
 
@@ -179,7 +179,7 @@ class FolderServiceTest {
 			void orderBySize_asc() {
 				// When
 				FolderContentsDto result = folderService.getFolderContents(parentFolder.getId(), 0L, CursorType.FOLDER,
-					20, FolderContentsSortField.DATA_SIZE, Sort.Direction.ASC, now, 0L);
+					20, FolderContentsSortField.DATA_SIZE, Sort.Direction.ASC, now, 0L, true);
 
 				// Then
 				List<FolderMetadata> resultFolders = result.folderMetadataList();
@@ -200,7 +200,7 @@ class FolderServiceTest {
 				// When
 				int limit = 10;
 				FolderContentsDto result = folderService.getFolderContents(parentFolder.getId(), 0L, CursorType.FOLDER,
-					limit, FolderContentsSortField.CREATED_AT, Sort.Direction.DESC, now, 0L);
+					limit, FolderContentsSortField.CREATED_AT, Sort.Direction.DESC, now, 0L, true);
 
 				// Then
 				assertEquals(limit, result.folderMetadataList().size() + result.fileMetadataList().size());


### PR DESCRIPTION
- resolves #30 

---

### 🚀 어떤 기능을 구현했나요 ?
- 폴더/파일 이동시에 이동한 폴더의 공유 권한으로 수정되어야한다.
- 다른 사람의 폴더 조회시에 공유되지 않은 폴더나 파일을 조회되지 않아야한다.

### 🔥 어떻게 해결했나요 ?
1. 폴더 조회
- 소유주의 요청이라면 모든 폴더및 파일 반환
- 다른 사람의 요청이라면 공유된 폴더 및 파일만 필터링해서 반환
- 매개변수로 ownerRequested 받아서 ownerRequested == False라면 조회 결과에서 공유되지 않은 폴더/파일 제외

2. 폴더/파일 이동시 이동한 폴더의 공유 상태 상속 수정
- 파일 이동시 기존 공유 상태 유지하지 않고 이동한 폴더의 공유 권한 상속받도록 수정
- 중복된 코드 방지 및 응집도 낮추기 위해서 이벤트 발행후 기존 SharedLinkService의 메서드 재사용
